### PR TITLE
Allow unsetting a charge-schedule

### DIFF
--- a/src/renault_api/cli/__main__.py
+++ b/src/renault_api/cli/__main__.py
@@ -188,7 +188,8 @@ async def charges(
 @click.option("--id", type=int, help="Schedule ID")
 @click.option("--set", is_flag=True, help="Update specified schedule.")
 @helpers.days_of_week_option(
-    helptext="{} schedule in format `HH:MM,DURATION` or `THH:MMZ,DURATION`."
+    helptext="{} schedule in format `HH:MM,DURATION` or `THH:MMZ,DURATION`"
+    "or `clear` to unset."
 )
 @click.pass_obj
 @helpers.coro_with_websession

--- a/src/renault_api/cli/renault_vehicle_charge.py
+++ b/src/renault_api/cli/renault_vehicle_charge.py
@@ -219,7 +219,10 @@ def update_settings(
     for day in DAYS_OF_WEEK:
         if day in kwargs:  # pragma: no branch
             day_value = kwargs.pop(day)
-            if day_value:
+
+            if day_value == "clear":
+                setattr(schedule, day, None)
+            elif day_value:
                 start_time, duration = _parse_day_schedule(str(day_value))
                 setattr(
                     schedule,

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -388,15 +388,17 @@ class HvacSchedule(BaseModel):
 
     def for_json(self) -> Dict[str, Any]:
         """Create dict for json."""
-        ret: Dict[str, Any] = {
+        result: Dict[str, Any] = {
             "id": self.id,
             "activated": self.activated,
         }
         for day in helpers.DAYS_OF_WEEK:
-            schedule: Optional[HvacDaySchedule] = self.__dict__.get(day)
-            if schedule:
-                ret[day] = schedule.for_json()
-        return ret
+            day_spec: Optional[HvacDaySchedule] = getattr(self, day, None)
+            if day_spec is None:
+                result[day] = day_spec
+            else:
+                result[day] = day_spec.for_json()
+        return result
 
 
 @dataclass

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -351,9 +351,11 @@ class ChargeSchedule(BaseModel):
             "activated": self.activated,
         }
         for day in helpers.DAYS_OF_WEEK:
-            schedule: Optional[ChargeDaySchedule] = self.__dict__.get(day)
-            if schedule:  # pragma: no branch
-                result[day] = schedule.for_json()
+            day_spec: Optional[ChargeDaySchedule] = getattr(self, day, None)
+            if day_spec is None:
+                result[day] = day_spec
+            else:
+                result[day] = day_spec.for_json()
         return result
 
 

--- a/tests/cli/test_vehicle_charge.py
+++ b/tests/cli/test_vehicle_charge.py
@@ -150,10 +150,11 @@ def test_charging_settings_set(
     fixtures.inject_get_charging_settings(mocked_responses)
     url = fixtures.inject_set_charge_schedule(mocked_responses, "schedules")
 
+    monday = "--monday clear"
     friday = "--friday T23:30Z,480"
     saturday = "--saturday 19:30,120"
     result = cli_runner.invoke(
-        __main__.main, f"charging-settings --id 1 --set {friday} {saturday}"
+        __main__.main, f"charging-settings --id 1 --set {monday} {friday} {saturday}"
     )
     assert result.exit_code == 0, result.exception
 
@@ -164,7 +165,7 @@ def test_charging_settings_set(
                     {
                         "id": 1,
                         "activated": True,
-                        "monday": {"duration": 15, "startTime": "T12:00Z"},
+                        "monday": None,
                         "tuesday": {"duration": 420, "startTime": "T04:30Z"},
                         "wednesday": {"duration": 420, "startTime": "T22:30Z"},
                         "thursday": {"duration": 420, "startTime": "T22:00Z"},
@@ -190,7 +191,6 @@ def test_charging_settings_set(
     }
     expected_output = (
         "{'schedules': [{'id': 1, 'activated': True, "
-        "'monday': {'startTime': 'T12:00Z', 'duration': 15}, "
         "'tuesday': {'startTime': 'T04:30Z', 'duration': 420}, "
         "'wednesday': {'startTime': 'T22:30Z', 'duration': 420}, "
         "'thursday': {'startTime': 'T22:00Z', 'duration': 420}, "

--- a/tests/fixtures/kamereon/vehicle_action/charge-schedule.schedules.json
+++ b/tests/fixtures/kamereon/vehicle_action/charge-schedule.schedules.json
@@ -7,10 +7,6 @@
         {
           "id": 1,
           "activated": true,
-          "monday": {
-            "startTime": "T12:00Z",
-            "duration": 15
-          },
           "tuesday": {
             "startTime": "T04:30Z",
             "duration": 420

--- a/tests/kamereon/test_kamereon_vehicle_action.py
+++ b/tests/kamereon/test_kamereon_vehicle_action.py
@@ -135,20 +135,47 @@ def test_hvac_schedule_for_json() -> None:
     for_json = {
         "schedules": list(schedule.for_json() for schedule in vehicle_data.schedules)
     }
-    assert for_json == {
+    expected_json = {
         "schedules": [
-            {"id": 1, "activated": False},
+            {
+                "id": 1,
+                "activated": False,
+                "monday": None,
+                "tuesday": None,
+                "wednesday": None,
+                "thursday": None,
+                "friday": None,
+                "saturday": None,
+                "sunday": None,
+            },
             {
                 "id": 2,
                 "activated": True,
+                "monday": None,
+                "tuesday": None,
                 "wednesday": {"readyAtTime": "T15:15Z"},
+                "thursday": None,
                 "friday": {"readyAtTime": "T15:15Z"},
+                "saturday": None,
+                "sunday": None,
             },
-            {"id": 3, "activated": False},
-            {"id": 4, "activated": False},
-            {"id": 5, "activated": False},
         ]
     }
+    for i in [3, 4, 5]:
+        expected_json["schedules"].append(
+            {
+                "id": i,
+                "activated": False,
+                "monday": None,
+                "tuesday": None,
+                "wednesday": None,
+                "thursday": None,
+                "friday": None,
+                "saturday": None,
+                "sunday": None,
+            }
+        )
+    assert for_json == expected_json
 
     # perform an update
     vehicle_data.schedules[0].activated = True
@@ -159,21 +186,45 @@ def test_hvac_schedule_for_json() -> None:
     for_json = {
         "schedules": list(schedule.for_json() for schedule in vehicle_data.schedules)
     }
-    assert for_json == {
+    expected_json = {
         "schedules": [
             {
                 "id": 1,
                 "activated": True,
+                "monday": None,
+                "tuesday": None,
+                "wednesday": None,
+                "thursday": None,
+                "friday": None,
+                "saturday": None,
                 "sunday": {"readyAtTime": "T20:30Z"},
             },
             {
                 "id": 2,
                 "activated": True,
+                "monday": None,
+                "tuesday": None,
                 "wednesday": {"readyAtTime": "T15:15Z"},
+                "thursday": None,
                 "friday": {"readyAtTime": "T15:15Z"},
+                "saturday": None,
+                "sunday": None,
             },
-            {"id": 3, "activated": False},
-            {"id": 4, "activated": False},
-            {"id": 5, "activated": False},
         ]
     }
+    for i in [3, 4, 5]:
+        expected_json["schedules"].append(
+            {
+                "id": i,
+                "activated": False,
+                "monday": None,
+                "tuesday": None,
+                "wednesday": None,
+                "thursday": None,
+                "friday": None,
+                "saturday": None,
+                "sunday": None,
+            }
+        )
+
+    assert for_json == expected_json


### PR DESCRIPTION
Both charge- and HVAC schedules can be unset (i.e., deleted from
serverside, which is more than mere inactivation). Users may want to use
this feature to have a less cluttered view, in both the official app,
the cars UI, and third-party applications.