### PR TITLE
Add raw HTTP GET/POST methods to CLI

### DIFF
--- a/src/renault_api/cli/__main__.py
+++ b/src/renault_api/cli/__main__.py
@@ -65,6 +65,7 @@ def _check_for_debug(debug: bool, log: bool) -> None:
 @click.version_option()
 @click.option("--debug", is_flag=True, help="Display debug traces.")
 @click.option("--log", is_flag=True, help="Log debug traces to file.")
+@click.option("--json", is_flag=True, help="Return data as JSON")
 @click.option("--locale", default=None, help="API locale (eg. fr_FR)")
 @click.option(
     "--account",
@@ -75,8 +76,10 @@ def _check_for_debug(debug: bool, log: bool) -> None:
 @click.pass_context
 def main(
     ctx: Context,
+    *,
     debug: bool,
     log: bool,
+    json: bool,
     locale: Optional[str] = None,
     account: Optional[str] = None,
     vin: Optional[str] = None,
@@ -87,6 +90,7 @@ def main(
         os.path.expanduser(renault_settings.CREDENTIAL_PATH)
     )
     _check_for_debug(debug, log)
+    ctx.obj["json"] = json
     if locale:
         ctx.obj["locale"] = locale
     if account:
@@ -206,6 +210,26 @@ async def contracts(
 ) -> None:
     """Display vehicle contracts."""
     await renault_vehicle.display_contracts(websession, ctx_data)
+
+
+@main.group()
+def http() -> None:
+    """Raw HTTP."""
+    pass
+
+
+@http.command(name="get")
+@click.argument("endpoint")
+@click.pass_obj
+@helpers.coro_with_websession
+async def http_get(
+    ctx_data: Dict[str, Any],
+    *,
+    endpoint: str,
+    websession: aiohttp.ClientSession,
+) -> None:
+    """Process HTTP GET request on endpoint."""
+    await renault_client.http_get(websession, ctx_data, endpoint)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/renault_api/cli/__main__.py
+++ b/src/renault_api/cli/__main__.py
@@ -1,8 +1,10 @@
 """Command-line interface."""
 import errno
+import json
 import logging
 import os
 from datetime import datetime
+from io import TextIOWrapper
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -230,6 +232,40 @@ async def http_get(
 ) -> None:
     """Process HTTP GET request on endpoint."""
     await renault_client.http_get(websession, ctx_data, endpoint)
+
+
+@http.command(name="post-file")
+@click.argument("endpoint")
+@click.argument("json-body", type=click.File("rb"))
+@click.pass_obj
+@helpers.coro_with_websession
+async def http_post_file(
+    ctx_data: Dict[str, Any],
+    *,
+    endpoint: str,
+    json_body: TextIOWrapper,
+    websession: aiohttp.ClientSession,
+) -> None:
+    """Process HTTP POST request on endpoint."""
+    await renault_client.http_post(websession, ctx_data, endpoint, json.load(json_body))
+
+
+@http.command(name="post")
+@click.argument("endpoint")
+@click.argument("json-body")
+@click.pass_obj
+@helpers.coro_with_websession
+async def http_post(
+    ctx_data: Dict[str, Any],
+    *,
+    endpoint: str,
+    json_body: str,
+    websession: aiohttp.ClientSession,
+) -> None:
+    """Process HTTP POST request on endpoint."""
+    await renault_client.http_post(
+        websession, ctx_data, endpoint, json.loads(json_body)
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/renault_api/cli/__main__.py
+++ b/src/renault_api/cli/__main__.py
@@ -231,7 +231,7 @@ async def http_get(
     websession: aiohttp.ClientSession,
 ) -> None:
     """Process HTTP GET request on endpoint."""
-    await renault_client.http_get(websession, ctx_data, endpoint)
+    await renault_client.http_request(websession, ctx_data, "GET", endpoint)
 
 
 @http.command(name="post-file")
@@ -247,7 +247,9 @@ async def http_post_file(
     websession: aiohttp.ClientSession,
 ) -> None:
     """Process HTTP POST request on endpoint."""
-    await renault_client.http_post(websession, ctx_data, endpoint, json.load(json_body))
+    await renault_client.http_request(
+        websession, ctx_data, "POST", endpoint, json.load(json_body)
+    )
 
 
 @http.command(name="post")
@@ -263,8 +265,8 @@ async def http_post(
     websession: aiohttp.ClientSession,
 ) -> None:
     """Process HTTP POST request on endpoint."""
-    await renault_client.http_post(
-        websession, ctx_data, endpoint, json.loads(json_body)
+    await renault_client.http_request(
+        websession, ctx_data, "POST", endpoint, json.loads(json_body)
     )
 
 

--- a/src/renault_api/cli/renault_client.py
+++ b/src/renault_api/cli/renault_client.py
@@ -124,25 +124,33 @@ async def display_accounts(
     click.echo(tabulate(accounts.items(), headers=["Type", "ID"]))
 
 
-async def http_get(
+async def http_get_endpoint(
     websession: aiohttp.ClientSession, ctx_data: Dict[str, Any], endpoint: str
-) -> None:
+) -> str:
     """Run HTTP GET request."""
-    if "{account_id}" in endpoint:
+    if "{account_id}" in endpoint:  # pragma: no branch
         account = await renault_account.get_account(
             websession=websession, ctx_data=ctx_data
         )
         endpoint = endpoint.replace("{account_id}", account.account_id)
-    if "{vin}" in endpoint:
+    if "{vin}" in endpoint:  # pragma: no branch
         vehicle = await renault_vehicle.get_vehicle(
             websession=websession, ctx_data=ctx_data
         )
         endpoint = endpoint.replace("{vin}", vehicle.vin)
+    return endpoint
+
+
+async def http_get(
+    websession: aiohttp.ClientSession, ctx_data: Dict[str, Any], endpoint: str
+) -> None:
+    """Run HTTP GET request."""
+    endpoint = await http_get_endpoint(websession, ctx_data, endpoint)
 
     session = await _get_logged_in_session(websession=websession, ctx_data=ctx_data)
     response = await session.http_get(endpoint)
 
-    if ctx_data["json"]:
+    if ctx_data["json"]:  # pragma: no cover
         click.echo(json.dumps(response.raw_data))
     else:
         click.echo(response.raw_data)
@@ -155,21 +163,12 @@ async def http_post(
     json_body: Dict[str, Any],
 ) -> None:
     """Run HTTP POST request."""
-    if "{account_id}" in endpoint:
-        account = await renault_account.get_account(
-            websession=websession, ctx_data=ctx_data
-        )
-        endpoint = endpoint.replace("{account_id}", account.account_id)
-    if "{vin}" in endpoint:
-        vehicle = await renault_vehicle.get_vehicle(
-            websession=websession, ctx_data=ctx_data
-        )
-        endpoint = endpoint.replace("{vin}", vehicle.vin)
+    endpoint = await http_get_endpoint(websession, ctx_data, endpoint)
 
     session = await _get_logged_in_session(websession=websession, ctx_data=ctx_data)
     response = await session.http_post(endpoint, json_body)
 
-    if ctx_data["json"]:
+    if ctx_data["json"]:  # pragma: no cover
         click.echo(json.dumps(response.raw_data))
     else:
         click.echo(response.raw_data)

--- a/src/renault_api/cli/renault_client.py
+++ b/src/renault_api/cli/renault_client.py
@@ -7,9 +7,9 @@ from typing import Dict
 import aiohttp
 import click
 from tabulate import tabulate
+
 from renault_api.cli import renault_account
 from renault_api.cli import renault_vehicle
-
 from renault_api.const import CONF_LOCALE
 from renault_api.credential import Credential
 from renault_api.credential_store import CredentialStore
@@ -141,6 +141,33 @@ async def http_get(
 
     session = await _get_logged_in_session(websession=websession, ctx_data=ctx_data)
     response = await session.http_get(endpoint)
+
+    if ctx_data["json"]:
+        click.echo(json.dumps(response.raw_data))
+    else:
+        click.echo(response.raw_data)
+
+
+async def http_post(
+    websession: aiohttp.ClientSession,
+    ctx_data: Dict[str, Any],
+    endpoint: str,
+    json_body: Dict[str, Any],
+) -> None:
+    """Run HTTP POST request."""
+    if "{account_id}" in endpoint:
+        account = await renault_account.get_account(
+            websession=websession, ctx_data=ctx_data
+        )
+        endpoint = endpoint.replace("{account_id}", account.account_id)
+    if "{vin}" in endpoint:
+        vehicle = await renault_vehicle.get_vehicle(
+            websession=websession, ctx_data=ctx_data
+        )
+        endpoint = endpoint.replace("{vin}", vehicle.vin)
+
+    session = await _get_logged_in_session(websession=websession, ctx_data=ctx_data)
+    response = await session.http_post(endpoint, json_body)
 
     if ctx_data["json"]:
         click.echo(json.dumps(response.raw_data))

--- a/src/renault_api/cli/renault_client.py
+++ b/src/renault_api/cli/renault_client.py
@@ -3,6 +3,7 @@ import json
 from locale import getdefaultlocale
 from typing import Any
 from typing import Dict
+from typing import Optional
 
 import aiohttp
 import click
@@ -141,32 +142,18 @@ async def http_get_endpoint(
     return endpoint
 
 
-async def http_get(
-    websession: aiohttp.ClientSession, ctx_data: Dict[str, Any], endpoint: str
-) -> None:
-    """Run HTTP GET request."""
-    endpoint = await http_get_endpoint(websession, ctx_data, endpoint)
-
-    session = await _get_logged_in_session(websession=websession, ctx_data=ctx_data)
-    response = await session.http_get(endpoint)
-
-    if ctx_data["json"]:  # pragma: no cover
-        click.echo(json.dumps(response.raw_data))
-    else:
-        click.echo(response.raw_data)
-
-
-async def http_post(
+async def http_request(
     websession: aiohttp.ClientSession,
     ctx_data: Dict[str, Any],
+    method: str,
     endpoint: str,
-    json_body: Dict[str, Any],
+    json_body: Optional[Dict[str, Any]] = None,
 ) -> None:
-    """Run HTTP POST request."""
+    """Run HTTP request."""
     endpoint = await http_get_endpoint(websession, ctx_data, endpoint)
 
     session = await _get_logged_in_session(websession=websession, ctx_data=ctx_data)
-    response = await session.http_post(endpoint, json_body)
+    response = await session.http_request(method, endpoint, json_body)
 
     if ctx_data["json"]:  # pragma: no cover
         click.echo(json.dumps(response.raw_data))

--- a/src/renault_api/gigya/__init__.py
+++ b/src/renault_api/gigya/__init__.py
@@ -28,12 +28,13 @@ async def request(
     """Send request to Gigya."""
     async with websession.request(method, url, data=data) as http_response:
         response_text = await http_response.text()
-        _LOGGER.debug(
-            "Received Gigya response %s on %s: %s",
-            http_response.status,
-            url,
-            response_text,
-        )
+        # Disable logging on Gigya, to avoid unnecessary exposure.
+        # _LOGGER.debug(
+        #    "Received Gigya response %s on %s: %s",
+        #    http_response.status,
+        #    url,
+        #    response_text,
+        # )
         gigya_response: models.GigyaResponse = schema.loads(response_text)
         # Check for Gigya error
         gigya_response.raise_for_error_code()

--- a/src/renault_api/kamereon/__init__.py
+++ b/src/renault_api/kamereon/__init__.py
@@ -1,5 +1,6 @@
 """Kamereon API."""
 import logging
+from json import dumps as json_dumps
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -118,14 +119,21 @@ async def request(
         json=json,
     ) as http_response:
         response_text = await http_response.text()
+        if json:
+            _LOGGER.debug(
+                "Send Kamereon %s request to %s with body: %s",
+                method,
+                http_response.url,
+                json_dumps(json),
+            )
         _LOGGER.debug(
-            "Received Kamereon response %s on %s %s: %s (with body data %s)",
+            "Received Kamereon response %s on %s to %s: %s",
             http_response.status,
             method,
             http_response.url,
             response_text,
-            json,
         )
+
         # Some endpoints return arrays instead of objects.
         # These need to be wrapped in an object.
         if response_text.startswith("[") and wrap_array_in:

--- a/src/renault_api/renault_session.py
+++ b/src/renault_api/renault_session.py
@@ -154,7 +154,7 @@ class RenaultSession:
                 self._credentials[gigya.GIGYA_JWT] = JWTCredential(jwt)
                 return jwt
 
-    async def http_get(self, endpoint: str) -> models.KamereonPersonResponse:
+    async def http_get(self, endpoint: str) -> models.KamereonResponse:
         """GET to specified endpoint."""
         if not endpoint.startswith("/"):
             endpoint = f"/{endpoint}"
@@ -167,6 +167,24 @@ class RenaultSession:
             api_key=await self._get_kamereon_api_key(),
             gigya_jwt=await self._get_jwt(),
             params=params,
+        )
+
+    async def http_post(
+        self, endpoint: str, json: Dict[str, Any]
+    ) -> models.KamereonResponse:
+        """POST to specified endpoint."""
+        if not endpoint.startswith("/"):
+            endpoint = f"/{endpoint}"
+        url = (await self._get_kamereon_root_url()) + endpoint
+        params = {"country": await self._get_country()}
+        return await kamereon.request(
+            websession=self._websession,
+            method="POST",
+            url=url,
+            api_key=await self._get_kamereon_api_key(),
+            gigya_jwt=await self._get_jwt(),
+            params=params,
+            json=json,
         )
 
     async def get_person(self) -> models.KamereonPersonResponse:

--- a/src/renault_api/renault_session.py
+++ b/src/renault_api/renault_session.py
@@ -154,28 +154,15 @@ class RenaultSession:
                 self._credentials[gigya.GIGYA_JWT] = JWTCredential(jwt)
                 return jwt
 
-    async def http_get(self, endpoint: str) -> models.KamereonResponse:
+    async def http_request(
+        self, method: str, endpoint: str, json: Optional[Dict[str, Any]] = None
+    ) -> models.KamereonResponse:
         """GET to specified endpoint."""
         url = (await self._get_kamereon_root_url()) + endpoint
         params = {"country": await self._get_country()}
         return await kamereon.request(
             websession=self._websession,
-            method="GET",
-            url=url,
-            api_key=await self._get_kamereon_api_key(),
-            gigya_jwt=await self._get_jwt(),
-            params=params,
-        )
-
-    async def http_post(
-        self, endpoint: str, json: Dict[str, Any]
-    ) -> models.KamereonResponse:
-        """POST to specified endpoint."""
-        url = (await self._get_kamereon_root_url()) + endpoint
-        params = {"country": await self._get_country()}
-        return await kamereon.request(
-            websession=self._websession,
-            method="POST",
+            method=method,
             url=url,
             api_key=await self._get_kamereon_api_key(),
             gigya_jwt=await self._get_jwt(),

--- a/src/renault_api/renault_session.py
+++ b/src/renault_api/renault_session.py
@@ -154,6 +154,21 @@ class RenaultSession:
                 self._credentials[gigya.GIGYA_JWT] = JWTCredential(jwt)
                 return jwt
 
+    async def http_get(self, endpoint: str) -> models.KamereonPersonResponse:
+        """GET to specified endpoint."""
+        if not endpoint.startswith("/"):
+            endpoint = f"/{endpoint}"
+        url = (await self._get_kamereon_root_url()) + endpoint
+        params = {"country": await self._get_country()}
+        return await kamereon.request(
+            websession=self._websession,
+            method="GET",
+            url=url,
+            api_key=await self._get_kamereon_api_key(),
+            gigya_jwt=await self._get_jwt(),
+            params=params,
+        )
+
     async def get_person(self) -> models.KamereonPersonResponse:
         """GET to /persons/{person_id}."""
         return await kamereon.get_person(

--- a/src/renault_api/renault_session.py
+++ b/src/renault_api/renault_session.py
@@ -156,8 +156,6 @@ class RenaultSession:
 
     async def http_get(self, endpoint: str) -> models.KamereonResponse:
         """GET to specified endpoint."""
-        if not endpoint.startswith("/"):
-            endpoint = f"/{endpoint}"
         url = (await self._get_kamereon_root_url()) + endpoint
         params = {"country": await self._get_country()}
         return await kamereon.request(
@@ -173,8 +171,6 @@ class RenaultSession:
         self, endpoint: str, json: Dict[str, Any]
     ) -> models.KamereonResponse:
         """POST to specified endpoint."""
-        if not endpoint.startswith("/"):
-            endpoint = f"/{endpoint}"
         url = (await self._get_kamereon_root_url()) + endpoint
         params = {"country": await self._get_country()}
         return await kamereon.request(

--- a/tests/cli/test_vehicle.py
+++ b/tests/cli/test_vehicle.py
@@ -2,10 +2,11 @@
 import json
 import os
 from locale import getdefaultlocale
-from aioresponses.core import RequestCall
+from typing import Any
 
 import pytest
 from aioresponses import aioresponses
+from aioresponses.core import RequestCall  # type:ignore
 from click.testing import CliRunner
 from tests import fixtures
 from tests.const import TEST_ACCOUNT_ID
@@ -279,7 +280,11 @@ def test_http_get(mocked_responses: aioresponses, cli_runner: CliRunner) -> None
 
     fixtures.inject_get_charging_settings(mocked_responses)
 
-    endpoint = "/commerce/v1/accounts/{account_id}/kamereon/kca/car-adapter/v1/cars/{vin}/charging-settings"
+    endpoint = (
+        "/commerce/v1/accounts/{account_id}"
+        "/kamereon/kca/car-adapter"
+        "/v1/cars/{vin}/charging-settings"
+    )
     result = cli_runner.invoke(
         __main__.main,
         f"http get {endpoint}",
@@ -322,7 +327,11 @@ def test_http_post(mocked_responses: aioresponses, cli_runner: CliRunner) -> Non
 
     url = fixtures.inject_set_charge_schedule(mocked_responses, "schedules")
 
-    endpoint = "/commerce/v1/accounts/{account_id}/kamereon/kca/car-adapter/v2/cars/{vin}/actions/charge-schedule"
+    endpoint = (
+        "/commerce/v1/accounts/{account_id}"
+        "/kamereon/kca/car-adapter"
+        "/v2/cars/{vin}/actions/charge-schedule"
+    )
     body = {"data": {"type": "ChargeSchedule", "attributes": {"schedules": []}}}
     json_body = json.dumps(body)
     result = cli_runner.invoke(
@@ -332,7 +341,8 @@ def test_http_post(mocked_responses: aioresponses, cli_runner: CliRunner) -> Non
     assert result.exit_code == 0, result.exception
 
     expected_output = (
-        "{'data': {'type': 'ChargeSchedule', 'id': 'guid', 'attributes': {'schedules': ["
+        "{'data': {'type': 'ChargeSchedule', 'id': 'guid', "
+        "'attributes': {'schedules': ["
         "{'id': 1, 'activated': True, "
         "'tuesday': {'startTime': 'T04:30Z', 'duration': 420}, "
         "'wednesday': {'startTime': 'T22:30Z', 'duration': 420}, "
@@ -352,7 +362,7 @@ def test_http_post(mocked_responses: aioresponses, cli_runner: CliRunner) -> Non
 
 
 def test_http_post_file(
-    tmpdir, mocked_responses: aioresponses, cli_runner: CliRunner
+    tmpdir: Any, mocked_responses: aioresponses, cli_runner: CliRunner
 ) -> None:
     """It exits with a status code of zero."""
     credential_store = FileCredentialStore(os.path.expanduser(CREDENTIAL_PATH))
@@ -365,9 +375,12 @@ def test_http_post_file(
 
     url = fixtures.inject_set_charge_schedule(mocked_responses, "schedules")
 
-    endpoint = "/commerce/v1/accounts/{account_id}/kamereon/kca/car-adapter/v2/cars/{vin}/actions/charge-schedule"
+    endpoint = (
+        "/commerce/v1/accounts/{account_id}"
+        "/kamereon/kca/car-adapter"
+        "/v2/cars/{vin}/actions/charge-schedule"
+    )
     body = {"data": {"type": "ChargeSchedule", "attributes": {"schedules": []}}}
-    json_body = json.dumps(body)
 
     json_file = tmpdir.mkdir("json").join("sample.json")
     json_file.write(json.dumps(body))
@@ -379,7 +392,8 @@ def test_http_post_file(
     assert result.exit_code == 0, result.exception
 
     expected_output = (
-        "{'data': {'type': 'ChargeSchedule', 'id': 'guid', 'attributes': {'schedules': ["
+        "{'data': {'type': 'ChargeSchedule', 'id': 'guid', "
+        "'attributes': {'schedules': ["
         "{'id': 1, 'activated': True, "
         "'tuesday': {'startTime': 'T04:30Z', 'duration': 420}, "
         "'wednesday': {'startTime': 'T22:30Z', 'duration': 420}, "

--- a/tests/cli/test_vehicle.py
+++ b/tests/cli/test_vehicle.py
@@ -1,6 +1,8 @@
 """Test cases for the __main__ module."""
+import json
 import os
 from locale import getdefaultlocale
+from aioresponses.core import RequestCall
 
 import pytest
 from aioresponses import aioresponses
@@ -13,6 +15,7 @@ from tests.const import TEST_PASSWORD
 from tests.const import TEST_PERSON_ID
 from tests.const import TEST_USERNAME
 from tests.const import TEST_VIN
+from yarl import URL
 
 from renault_api.cli import __main__
 from renault_api.cli.renault_settings import CONF_ACCOUNT_ID
@@ -262,3 +265,134 @@ def test_vehicle_contracts(
         "Garantie assistance                           2020-04-03  Expiré\n"
     )
     assert expected_output == result.output
+
+
+def test_http_get(mocked_responses: aioresponses, cli_runner: CliRunner) -> None:
+    """It exits with a status code of zero."""
+    credential_store = FileCredentialStore(os.path.expanduser(CREDENTIAL_PATH))
+    credential_store[CONF_LOCALE] = Credential(TEST_LOCALE)
+    credential_store[CONF_ACCOUNT_ID] = Credential(TEST_ACCOUNT_ID)
+    credential_store[CONF_VIN] = Credential(TEST_VIN)
+    credential_store[GIGYA_LOGIN_TOKEN] = Credential(TEST_LOGIN_TOKEN)
+    credential_store[GIGYA_PERSON_ID] = Credential(TEST_PERSON_ID)
+    credential_store[GIGYA_JWT] = JWTCredential(fixtures.get_jwt())
+
+    fixtures.inject_get_charging_settings(mocked_responses)
+
+    endpoint = "/commerce/v1/accounts/{account_id}/kamereon/kca/car-adapter/v1/cars/{vin}/charging-settings"
+    result = cli_runner.invoke(
+        __main__.main,
+        f"http get {endpoint}",
+    )
+    assert result.exit_code == 0, result.exception
+
+    expected_output = (
+        "{'data': {'type': 'Car', 'id': 'VF1AAAAA555777999', 'attributes': {"
+        "'mode': 'scheduled', 'schedules': ["
+        "{'id': 1, 'activated': True, "
+        "'monday': {'startTime': 'T12:00Z', 'duration': 15}, "
+        "'tuesday': {'startTime': 'T04:30Z', 'duration': 420}, "
+        "'wednesday': {'startTime': 'T22:30Z', 'duration': 420}, "
+        "'thursday': {'startTime': 'T22:00Z', 'duration': 420}, "
+        "'friday': {'startTime': 'T12:15Z', 'duration': 15}, "
+        "'saturday': {'startTime': 'T12:30Z', 'duration': 30}, "
+        "'sunday': {'startTime': 'T12:45Z', 'duration': 45}}, "
+        "{'id': 2, 'activated': False, "
+        "'monday': {'startTime': 'T01:00Z', 'duration': 15}, "
+        "'tuesday': {'startTime': 'T02:00Z', 'duration': 30}, "
+        "'wednesday': {'startTime': 'T03:00Z', 'duration': 45}, "
+        "'thursday': {'startTime': 'T04:00Z', 'duration': 60}, "
+        "'friday': {'startTime': 'T05:00Z', 'duration': 75}, "
+        "'saturday': {'startTime': 'T06:00Z', 'duration': 90}, "
+        "'sunday': {'startTime': 'T07:00Z', 'duration': 105}}"
+        "]}}}\n"
+    )
+    assert expected_output == result.output
+
+
+def test_http_post(mocked_responses: aioresponses, cli_runner: CliRunner) -> None:
+    """It exits with a status code of zero."""
+    credential_store = FileCredentialStore(os.path.expanduser(CREDENTIAL_PATH))
+    credential_store[CONF_LOCALE] = Credential(TEST_LOCALE)
+    credential_store[CONF_ACCOUNT_ID] = Credential(TEST_ACCOUNT_ID)
+    credential_store[CONF_VIN] = Credential(TEST_VIN)
+    credential_store[GIGYA_LOGIN_TOKEN] = Credential(TEST_LOGIN_TOKEN)
+    credential_store[GIGYA_PERSON_ID] = Credential(TEST_PERSON_ID)
+    credential_store[GIGYA_JWT] = JWTCredential(fixtures.get_jwt())
+
+    url = fixtures.inject_set_charge_schedule(mocked_responses, "schedules")
+
+    endpoint = "/commerce/v1/accounts/{account_id}/kamereon/kca/car-adapter/v2/cars/{vin}/actions/charge-schedule"
+    body = {"data": {"type": "ChargeSchedule", "attributes": {"schedules": []}}}
+    json_body = json.dumps(body)
+    result = cli_runner.invoke(
+        __main__.main,
+        f"http post {endpoint} '{json_body}'",
+    )
+    assert result.exit_code == 0, result.exception
+
+    expected_output = (
+        "{'data': {'type': 'ChargeSchedule', 'id': 'guid', 'attributes': {'schedules': ["
+        "{'id': 1, 'activated': True, "
+        "'tuesday': {'startTime': 'T04:30Z', 'duration': 420}, "
+        "'wednesday': {'startTime': 'T22:30Z', 'duration': 420}, "
+        "'thursday': {'startTime': 'T22:00Z', 'duration': 420}, "
+        "'friday': {'startTime': 'T23:30Z', 'duration': 480}, "
+        "'saturday': {'startTime': 'T18:30Z', 'duration': 120}, "
+        "'sunday': {'startTime': 'T12:45Z', 'duration': 45}}]}}}\n"
+    )
+    assert expected_output == result.output
+
+    expected_json = {
+        "data": {"type": "ChargeSchedule", "attributes": {"schedules": []}}
+    }
+
+    request: RequestCall = mocked_responses.requests[("POST", URL(url))][0]
+    assert expected_json == request.kwargs["json"]
+
+
+def test_http_post_file(
+    tmpdir, mocked_responses: aioresponses, cli_runner: CliRunner
+) -> None:
+    """It exits with a status code of zero."""
+    credential_store = FileCredentialStore(os.path.expanduser(CREDENTIAL_PATH))
+    credential_store[CONF_LOCALE] = Credential(TEST_LOCALE)
+    credential_store[CONF_ACCOUNT_ID] = Credential(TEST_ACCOUNT_ID)
+    credential_store[CONF_VIN] = Credential(TEST_VIN)
+    credential_store[GIGYA_LOGIN_TOKEN] = Credential(TEST_LOGIN_TOKEN)
+    credential_store[GIGYA_PERSON_ID] = Credential(TEST_PERSON_ID)
+    credential_store[GIGYA_JWT] = JWTCredential(fixtures.get_jwt())
+
+    url = fixtures.inject_set_charge_schedule(mocked_responses, "schedules")
+
+    endpoint = "/commerce/v1/accounts/{account_id}/kamereon/kca/car-adapter/v2/cars/{vin}/actions/charge-schedule"
+    body = {"data": {"type": "ChargeSchedule", "attributes": {"schedules": []}}}
+    json_body = json.dumps(body)
+
+    json_file = tmpdir.mkdir("json").join("sample.json")
+    json_file.write(json.dumps(body))
+
+    result = cli_runner.invoke(
+        __main__.main,
+        f"http post-file {endpoint} '{json_file}'",
+    )
+    assert result.exit_code == 0, result.exception
+
+    expected_output = (
+        "{'data': {'type': 'ChargeSchedule', 'id': 'guid', 'attributes': {'schedules': ["
+        "{'id': 1, 'activated': True, "
+        "'tuesday': {'startTime': 'T04:30Z', 'duration': 420}, "
+        "'wednesday': {'startTime': 'T22:30Z', 'duration': 420}, "
+        "'thursday': {'startTime': 'T22:00Z', 'duration': 420}, "
+        "'friday': {'startTime': 'T23:30Z', 'duration': 480}, "
+        "'saturday': {'startTime': 'T18:30Z', 'duration': 120}, "
+        "'sunday': {'startTime': 'T12:45Z', 'duration': 45}}]}}}\n"
+    )
+    assert expected_output == result.output
+
+    expected_json = {
+        "data": {"type": "ChargeSchedule", "attributes": {"schedules": []}}
+    }
+
+    request: RequestCall = mocked_responses.requests[("POST", URL(url))][0]
+    assert expected_json == request.kwargs["json"]


### PR DESCRIPTION
`renault-api http get ENDPOINT`
For example: `renault-api http get /commerce/v1/accounts/{account_id}/kamereon/kca/car-adapter/v1/cars/{vin}/charging-settings`

`renault-api http post ENDPOINT JSON_BODY`
For example: `renault-api http get /commerce/v1/accounts/{account_id}/kamereon/kca/car-adapter/v2/cars/{vin}/actions/charge-schedule '{\"data\":{\"type\":\"ChargeSchedule\",\"attributes\":{\"schedules\":[{\"id\":1,\"activated\":true,\"monday\":{\"startTime\":\"T22:45Z\",\"duration\":495},\"tuesday\":{\"startTime\":\"T22:45Z\",\"duration\":495},\"wednesday\":{\"startTime\":\"T22:45Z\",\"duration\":495},\"thursday\":{\"startTime\":\"T22:45Z\",\"duration\":495},\"friday\":{\"startTime\":\"T22:45Z\",\"duration\":495},\"saturday\":{\"startTime\":\"T22:45Z\",\"duration\":495},\"sunday\":{\"startTime\":\"T22:45Z\",\"duration\":495}}]}}}'`

`renault-api http post-file ENDPOINT JSON_FILE`
For example: `renault-api http get /commerce/v1/accounts/{account_id}/kamereon/kca/car-adapter/v2/cars/{vin}/actions/charge-schedule schedule.json`