### PR TITLE
Fix error parsing on Response models

### DIFF
--- a/src/renault_api/cli/renault_account.py
+++ b/src/renault_api/cli/renault_account.py
@@ -78,7 +78,12 @@ async def _get_account_prompt(
         if account.accountType == "MYRENAULT":
             default = str(i + 1)
         account_table.append(
-            [i + 1, account.accountId, account.accountType, len(vehicles.vehicleLinks)]
+            [
+                i + 1,
+                account.accountId,
+                account.accountType,
+                0 if vehicles.vehicleLinks is None else len(vehicles.vehicleLinks),
+            ]
         )
 
     menu = tabulate(account_table, headers=["", "ID", "Type", "Vehicles"])
@@ -104,6 +109,8 @@ async def display_vehicles(
     account = await get_account(websession, ctx_data)
 
     response = await account.get_vehicles()
+    if response.vehicleLinks is None:  # pragma: no cover
+        raise ValueError("response.vehicleLinks is None")
     vehicles = [
         [
             vehicle.raw_data["vehicleDetails"]["registrationNumber"],

--- a/src/renault_api/cli/renault_client.py
+++ b/src/renault_api/cli/renault_client.py
@@ -121,6 +121,8 @@ async def display_accounts(
     """Display accounts."""
     client = await get_logged_in_client(websession=websession, ctx_data=ctx_data)
     response = await client.get_person()
+    if response.accounts is None:  # pragma: no cover
+        raise ValueError("response.accounts is None")
     accounts = {account.accountType: account.accountId for account in response.accounts}
     click.echo(tabulate(accounts.items(), headers=["Type", "ID"]))
 

--- a/src/renault_api/kamereon/__init__.py
+++ b/src/renault_api/kamereon/__init__.py
@@ -75,7 +75,7 @@ def get_required_contracts(endpoint: str) -> str:
 
 
 def has_required_contracts(
-    contracts: List[models.KameronVehicleContract], endpoint: str
+    contracts: List[models.KamereonVehicleContract], endpoint: str
 ) -> bool:
     """Check if vehicle has contract for endpoint."""
     required_contracts = get_required_contracts(endpoint)
@@ -181,7 +181,7 @@ async def get_vehicle_contracts(
     locale: str,
     account_id: str,
     vin: str,
-) -> models.KameronVehicleContractsReponse:
+) -> models.KamereonVehicleContractsResponse:
     """GET to /accounts/{accountId}/vehicles/{vin}/contracts."""
     url = get_contracts_url(root_url, account_id, vin)
     params = {
@@ -194,7 +194,7 @@ async def get_vehicle_contracts(
     }
 
     return cast(
-        models.KameronVehicleContractsReponse,
+        models.KamereonVehicleContractsResponse,
         await request(
             websession,
             "GET",
@@ -202,7 +202,7 @@ async def get_vehicle_contracts(
             api_key,
             gigya_jwt,
             params=params,
-            schema=schemas.KameronVehicleContractsReponseSchema,
+            schema=schemas.KamereonVehicleContractsResponseSchema,
             wrap_array_in="contractList",
         ),
     )

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -240,8 +240,8 @@ class KamereonVehicleDataAttributes(BaseModel):
 
 
 @dataclass
-class KameronVehicleContract(BaseModel):
-    """Kameron vehicle contract."""
+class KamereonVehicleContract(BaseModel):
+    """Kamereon vehicle contract."""
 
     type: Optional[str]
     contractId: Optional[str]  # noqa: N815
@@ -256,10 +256,10 @@ class KameronVehicleContract(BaseModel):
 
 
 @dataclass
-class KameronVehicleContractsReponse(KamereonResponse):
+class KamereonVehicleContractsResponse(KamereonResponse):
     """Kamereon response to GET on /accounts/{accountId}/vehicles/{vin}/contracts."""
 
-    contractList: List[KameronVehicleContract]  # noqa: N815
+    contractList: Optional[List[KamereonVehicleContract]]  # noqa: N815
 
 
 @dataclass

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -226,7 +226,7 @@ class KamereonVehiclesResponse(KamereonResponse):
 
     accountId: Optional[str]  # noqa: N815
     country: Optional[str]
-    vehicleLinks: List[KamereonVehiclesLink]  # noqa: N815
+    vehicleLinks: Optional[List[KamereonVehiclesLink]]  # noqa: N815
 
 
 @dataclass

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -127,7 +127,7 @@ class KamereonPersonAccount(BaseModel):
 class KamereonPersonResponse(KamereonResponse):
     """Kamereon response to GET on /persons/{gigya_person_id}."""
 
-    accounts: List[KamereonPersonAccount]
+    accounts: Optional[List[KamereonPersonAccount]]
 
 
 @dataclass

--- a/src/renault_api/kamereon/schemas.py
+++ b/src/renault_api/kamereon/schemas.py
@@ -15,8 +15,8 @@ KamereonPersonResponseSchema = marshmallow_dataclass.class_schema(
 )()
 
 
-KameronVehicleContractsReponseSchema = marshmallow_dataclass.class_schema(
-    models.KameronVehicleContractsReponse, base_schema=BaseSchema
+KamereonVehicleContractsResponseSchema = marshmallow_dataclass.class_schema(
+    models.KamereonVehicleContractsResponse, base_schema=BaseSchema
 )()
 
 KamereonVehiclesResponseSchema = marshmallow_dataclass.class_schema(

--- a/src/renault_api/renault_account.py
+++ b/src/renault_api/renault_account.py
@@ -66,6 +66,8 @@ class RenaultAccount:
     async def get_api_vehicles(self) -> List[RenaultVehicle]:
         """Get vehicle proxies."""
         response = await self.get_vehicles()
+        if response.vehicleLinks is None:  # pragma: no cover
+            raise ValueError("response.accounts is None")
         result: List[RenaultVehicle] = []
         for vehicle in response.vehicleLinks:
             if vehicle.vin is None:  # pragma: no cover

--- a/src/renault_api/renault_client.py
+++ b/src/renault_api/renault_client.py
@@ -56,6 +56,8 @@ class RenaultClient:
     async def get_api_accounts(self) -> List[RenaultAccount]:
         """Get account proxies."""
         response = await self.get_person()
+        if response.accounts is None:  # pragma: no cover
+            raise ValueError("response.accounts is None")
         result: List[RenaultAccount] = []
         for account in response.accounts:
             if account.accountId is None:  # pragma: no cover

--- a/src/renault_api/renault_session.py
+++ b/src/renault_api/renault_session.py
@@ -232,8 +232,7 @@ class RenaultSession:
         self,
         account_id: str,
         vin: str,
-        params: Optional[Dict[str, str]] = None,
-    ) -> models.KameronVehicleContractsReponse:
+    ) -> models.KamereonVehicleContractsResponse:
         """GET to /v{endpoint_version}/cars/{vin}/contracts."""
         return await kamereon.get_vehicle_contracts(
             websession=self._websession,

--- a/src/renault_api/renault_vehicle.py
+++ b/src/renault_api/renault_vehicle.py
@@ -46,7 +46,7 @@ class RenaultVehicle:
         self._account_id = account_id
         self._vin = vin
         self._vehicle_details = vehicle_details
-        self._contracts: Optional[List[models.KameronVehicleContract]] = None
+        self._contracts: Optional[List[models.KamereonVehicleContract]] = None
 
         if session:
             self._session = session
@@ -93,7 +93,7 @@ class RenaultVehicle:
         )
         return self._vehicle_details
 
-    async def get_contracts(self) -> List[models.KameronVehicleContract]:
+    async def get_contracts(self) -> List[models.KamereonVehicleContract]:
         """Get vehicle contracts."""
         # await self.warn_on_method("get_contracts")
         if self._contracts:
@@ -103,6 +103,8 @@ class RenaultVehicle:
             account_id=self.account_id,
             vin=self.vin,
         )
+        if response.contractList is None:  # pragma: no cover
+            raise ValueError("response.contractList is None")
         self._contracts = response.contractList
         return self._contracts
 

--- a/tests/kamereon/test_kamereon_error.py
+++ b/tests/kamereon/test_kamereon_error.py
@@ -1,10 +1,20 @@
 """Tests for Kamereon models."""
 import pytest
+from marshmallow.schema import Schema
 from tests import fixtures
 
 from renault_api.kamereon import exceptions
 from renault_api.kamereon import models
 from renault_api.kamereon import schemas
+
+RESPONSE_SCHEMAS = [
+    schemas.KamereonResponseSchema,
+    schemas.KamereonPersonResponseSchema,
+    schemas.KamereonVehiclesResponseSchema,
+    schemas.KamereonVehicleContractsResponseSchema,
+    schemas.KamereonVehicleDetailsResponseSchema,
+    schemas.KamereonVehicleDataResponseSchema,
+]
 
 
 @pytest.mark.parametrize(
@@ -95,6 +105,19 @@ def test_vehicle_error_access_denied() -> None:
     response: models.KamereonVehicleDataResponse = fixtures.get_file_content_as_schema(
         f"{fixtures.KAMEREON_FIXTURE_PATH}/error/access_denied.json",
         schemas.KamereonVehicleDataResponseSchema,
+    )
+    with pytest.raises(exceptions.AccessDeniedException) as excinfo:
+        response.raise_for_error_code()
+    assert excinfo.value.error_code == "err.func.403"
+    assert excinfo.value.error_details == "Access is denied for this resource"
+
+
+@pytest.mark.parametrize("target_schema", RESPONSE_SCHEMAS)
+def test_error_on_schema(target_schema: Schema) -> None:
+    """Test vehicle access_denied response."""
+    response: models.KamereonResponse = fixtures.get_file_content_as_schema(
+        f"{fixtures.KAMEREON_FIXTURE_PATH}/error/access_denied.json",
+        target_schema,
     )
     with pytest.raises(exceptions.AccessDeniedException) as excinfo:
         response.raise_for_error_code()

--- a/tests/kamereon/test_kamereon_vehicle_contract.py
+++ b/tests/kamereon/test_kamereon_vehicle_contract.py
@@ -15,7 +15,7 @@ def test_vehicle_contract_response(filename: str) -> None:
     """Test vehicle contract response."""
     response: models.KameronVehicleContractsReponse = (
         fixtures.get_file_content_as_wrapped_schema(
-            filename, schemas.KameronVehicleContractsReponseSchema, "contractList"
+            filename, schemas.KamereonVehicleContractsResponseSchema, "contractList"
         )
     )
     response.raise_for_error_code()
@@ -32,7 +32,7 @@ def test_has_required_contract_1() -> None:
     response: models.KameronVehicleContractsReponse = (
         fixtures.get_file_content_as_wrapped_schema(
             f"{fixtures.KAMEREON_FIXTURE_PATH}/vehicle_contract/fr_FR.1.json",
-            schemas.KameronVehicleContractsReponseSchema,
+            schemas.KamereonVehicleContractsResponseSchema,
             "contractList",
         )
     )
@@ -52,7 +52,7 @@ def test_has_required_contract_2() -> None:
     response: models.KameronVehicleContractsReponse = (
         fixtures.get_file_content_as_wrapped_schema(
             f"{fixtures.KAMEREON_FIXTURE_PATH}/vehicle_contract/fr_FR.2.json",
-            schemas.KameronVehicleContractsReponseSchema,
+            schemas.KamereonVehicleContractsResponseSchema,
             "contractList",
         )
     )

--- a/tests/test_renault_client.py
+++ b/tests/test_renault_client.py
@@ -41,6 +41,7 @@ async def test_get_person(
     """Test get_person."""
     fixtures.inject_get_person(mocked_responses)
     person = await client.get_person()
+    assert person.accounts is not None
     assert len(person.accounts) == 2
 
 


### PR DESCRIPTION
Adjust `KamereonPersonResponse.accounts`, `KamereonVehiclesResponse.vehicleLinks` and `KameronVehicleContractsReponse.contractList` properties to ensure error parsing still works.