### PR TITLE
Drop requires-contracts from endpoint definitions.

### DIFF
--- a/src/renault_api/kamereon/__init__.py
+++ b/src/renault_api/kamereon/__init__.py
@@ -20,13 +20,13 @@ _LOGGER = logging.getLogger(__name__)
 DATA_ENDPOINTS: Dict[str, Any] = {
     "battery-status": {"version": 2},
     "charge-history": {"version": 1},
-    "charge-mode": {"version": 1, "requires-contracts": "ZEINTER"},
+    "charge-mode": {"version": 1},
     "charges": {"version": 1},
-    "charging-settings": {"version": 1, "requires-contracts": "ZEINTER"},
+    "charging-settings": {"version": 1},
     "cockpit": {"version": 2},
-    "hvac-history": {"version": 1, "requires-contracts": "ZEINTER"},
-    "hvac-sessions": {"version": 1, "requires-contracts": "ZEINTER"},
-    "hvac-status": {"version": 1, "requires-contracts": "ZEINTER"},
+    "hvac-history": {"version": 1},
+    "hvac-sessions": {"version": 1},
+    "hvac-status": {"version": 1},
     "hvac-settings": {"version": 1},
     "location": {"version": 1},
     "lock-status": {"version": 1},
@@ -70,6 +70,8 @@ def get_contracts_url(root_url: str, account_id: str, vin: str) -> str:
 
 def get_required_contracts(endpoint: str) -> str:
     """Get the required contracts for the specified endpoint."""
+    # Contract codes are country-specific and can't be used to guess requirements.
+    # Implementation was therefore removed in 0.1.3.
     endpoints = ACTION_ENDPOINTS if endpoint.startswith("action") else DATA_ENDPOINTS
     return str(endpoints.get(endpoint, {}).get("requires-contracts", ""))
 
@@ -79,17 +81,17 @@ def has_required_contracts(
 ) -> bool:
     """Check if vehicle has contract for endpoint."""
     required_contracts = get_required_contracts(endpoint)
-    if not required_contracts:
+    if not required_contracts:  # pragma: no branch
         return True
 
-    for required_contract in required_contracts.split(","):
+    for required_contract in required_contracts.split(","):  # pragma: no cover
         if required_contract and not any(
             contract.code == required_contract and contract.status == "ACTIVE"
             for contract in contracts
         ):
             return False
 
-    return True
+    return True  # pragma: no cover
 
 
 async def request(

--- a/src/renault_api/renault_vehicle.py
+++ b/src/renault_api/renault_vehicle.py
@@ -512,11 +512,11 @@ class RenaultVehicle:
     async def has_contract_for_endpoint(self, endpoint: str) -> bool:
         """Check if vehicle has contract for endpoint."""
         required_contracts = get_required_contracts(endpoint)
-        if not required_contracts:
+        if not required_contracts:  # pragma: no branch
             return True
 
-        contracts = await self.get_contracts()
-        return has_required_contracts(contracts, endpoint)
+        contracts = await self.get_contracts()  # pragma: no cover
+        return has_required_contracts(contracts, endpoint)  # pragma: no cover
 
     async def warn_on_method(self, method: str) -> None:
         """Log a warning if the method requires it."""

--- a/tests/kamereon/test_kamereon_vehicle_contract.py
+++ b/tests/kamereon/test_kamereon_vehicle_contract.py
@@ -40,11 +40,13 @@ def test_has_required_contract_1() -> None:
     assert response.contractList is not None
 
     assert has_required_contracts(response.contractList, "battery-status")
-    assert not has_required_contracts(response.contractList, "charge-mode")
-    assert not has_required_contracts(response.contractList, "charging-settings")
-    assert not has_required_contracts(response.contractList, "hvac-history")
-    assert not has_required_contracts(response.contractList, "hvac-sessions")
-    assert not has_required_contracts(response.contractList, "hvac-status")
+    # "Deprecated in 0.1.3, contract codes are country-specific"
+    # " and can't be used to guess requirements."
+    # assert not has_required_contracts(response.contractList, "charge-mode")
+    # assert not has_required_contracts(response.contractList, "charging-settings")
+    # assert not has_required_contracts(response.contractList, "hvac-history")
+    # assert not has_required_contracts(response.contractList, "hvac-sessions")
+    # assert not has_required_contracts(response.contractList, "hvac-status")
 
 
 def test_has_required_contract_2() -> None:

--- a/tests/test_renault_vehicle.py
+++ b/tests/test_renault_vehicle.py
@@ -94,8 +94,10 @@ async def test_has_contract_for_endpoint_2(
     """Test has_contract_for_endpoint."""
     fixtures.inject_get_vehicle_contracts(mocked_responses, "fr_FR.1.json")
     assert await vehicle.has_contract_for_endpoint("battery-status")
-    assert not await vehicle.has_contract_for_endpoint("hvac-status")
-    assert not await vehicle.has_contract_for_endpoint("charge-mode")
+    # "Deprecated in 0.1.3, contract codes are country-specific"
+    # " and can't be used to guess requirements."
+    # assert not await vehicle.has_contract_for_endpoint("hvac-status")
+    # assert not await vehicle.has_contract_for_endpoint("charge-mode")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Contract codes are country-specific and can't be used to guess requirements.
See https://github.com/hacf-fr/renault-api/issues/194