### PR TITLE
Bump urllib3 from 1.26.4 to 1.26.5

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1177,16 +1177,16 @@ pytz = "*"
 
 [[package]]
 name = "urllib3"
-version = "1.26.4"
+version = "1.26.5"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
-brotli = ["brotlipy (>=0.6.0)"]
 
 [[package]]
 name = "virtualenv"
@@ -1258,7 +1258,7 @@ cli = ["click", "tabulate", "dateparser"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "384725e77188cda97ac3c63035770daa141df164597efd1e3f745706f1e33cc6"
+content-hash = "bd73e9e92f54cfd08068c3ebec71b953dd1bb30b58d69bb120513be82307e256"
 
 [metadata.files]
 aiohttp = [
@@ -2147,8 +2147,8 @@ tzlocal = [
     {file = "tzlocal-2.1.tar.gz", hash = "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
-    {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
+    {file = "urllib3-1.26.5-py2.py3-none-any.whl", hash = "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"},
+    {file = "urllib3-1.26.5.tar.gz", hash = "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"},
 ]
 virtualenv = [
     {file = "virtualenv-20.2.1-py2.py3-none-any.whl", hash = "sha256:07cff122e9d343140366055f31be4dcd61fd598c69d11cd33a9d9c8df4546dd7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ Pygments = "^2.10.0"
 pytest-asyncio = "^0.16.0"
 aioresponses = "^0.7.2"
 pytest-cov = "^3.0.0"
+#ensure urllib3 is greater than 1.26.5 to account for CVE-2021-33503
+urllib3 = "^1.26.5"
 
 [tool.poetry.extras]
 cli = ["click", "tabulate", "dateparser"]


### PR DESCRIPTION
Ensure urllib3 is greater than 1.26.5 to account for CVE-2021-33503