### PR TITLE
Use correct unit in charge history durations

### DIFF
--- a/src/renault_api/cli/helpers.py
+++ b/src/renault_api/cli/helpers.py
@@ -178,8 +178,8 @@ def convert_minutes_to_tztime(minutes: int) -> str:
     return f"T{hours:02g}:{minutes:02g}Z"
 
 
-def _format_minutes(mins: float) -> str:
-    d = timedelta(minutes=mins)
+def _format_seconds(secs: float) -> str:
+    d = timedelta(seconds=secs)
     return str(d)
 
 
@@ -197,7 +197,9 @@ def get_display_value(
     if unit == "tztime":
         return _format_tztime(value)
     if unit == "minutes":
-        return _format_minutes(value)
+        return _format_seconds(value * 60)
+    if unit == "seconds":
+        return _format_seconds(value)
     if unit == "kW":
         value = value / 1000
         return f"{value:.2f} {unit}"

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -47,6 +47,7 @@ COMMON_ERRRORS: List[Dict[str, Any]] = [
 
 VEHICLE_SPECIFICATIONS: Dict[str, Dict[str, Any]] = {
     "X101VE": {  # ZOE phase 1
+        "reports-durations-in-minutes": True,
         "reports-in-watts": True,
         "support-endpoint-location": False,
         "support-endpoint-lock-status": False,
@@ -64,6 +65,7 @@ VEHICLE_SPECIFICATIONS: Dict[str, Dict[str, Any]] = {
 
 GATEWAY_SPECIFICATIONS: Dict[str, Dict[str, Any]] = {
     "GDC": {  # ZOE phase 1
+        "reports-durations-in-minutes": True,
         "reports-in-watts": True,
         "support-endpoint-location": False,
         "support-endpoint-lock-status": False,
@@ -198,6 +200,15 @@ class KamereonVehicleDetails(BaseModel):
         ]:
             return True
         return False
+
+    def reports_duration_in_minutes(self) -> bool:
+        """Return True if model reports history durations in minutes."""
+        # Default to False (=seconds) for unknown vehicles
+        if self.model and self.model.code:
+            return VEHICLE_SPECIFICATIONS.get(self.model.code, {}).get(
+                "reports-durations-in-minutes", False
+            )
+        return False  # pragma: no cover
 
     def reports_charging_power_in_watts(self) -> bool:
         """Return True if model reports chargingInstantaneousPower in watts."""

--- a/tests/cli/test_vehicle_charge.py
+++ b/tests/cli/test_vehicle_charge.py
@@ -14,6 +14,7 @@ def test_charge_history_day(
 ) -> None:
     """It exits with a status code of zero."""
     initialise_credential_store(include_account_id=True, include_vin=True)
+    fixtures.inject_get_vehicle_details(mocked_responses, "zoe_40.1.json")
     fixtures.inject_get_charge_history(
         mocked_responses, start="20201101", end="20201130", period="day"
     )
@@ -37,6 +38,7 @@ def test_charge_history_month(
 ) -> None:
     """It exits with a status code of zero."""
     initialise_credential_store(include_account_id=True, include_vin=True)
+    fixtures.inject_get_vehicle_details(mocked_responses, "zoe_40.1.json")
     fixtures.inject_get_charge_history(
         mocked_responses, start="202011", end="202011", period="month"
     )
@@ -84,9 +86,10 @@ def test_charge_mode_set(mocked_responses: aioresponses, cli_runner: CliRunner) 
     assert expected_output == result.output
 
 
-def test_sessions(mocked_responses: aioresponses, cli_runner: CliRunner) -> None:
+def test_sessions_40(mocked_responses: aioresponses, cli_runner: CliRunner) -> None:
     """It exits with a status code of zero."""
     initialise_credential_store(include_account_id=True, include_vin=True)
+    fixtures.inject_get_vehicle_details(mocked_responses, "zoe_40.1.json")
     fixtures.inject_get_charges(mocked_responses, start="20201101", end="20201130")
 
     result = cli_runner.invoke(
@@ -101,6 +104,47 @@ def test_sessions(mocked_responses: aioresponses, cli_runner: CliRunner) -> None
         "  ------------  -------------  ---------------  -------------  --------\n"
         "2020-11-11 01:31:03  2020-11-11 09:30:17  7:59:00     3.10 kW     "
         "  15 %          74 %           59 %             slow           ok\n"
+    )
+    assert expected_output == result.output
+
+
+def test_sessions_50(mocked_responses: aioresponses, cli_runner: CliRunner) -> None:
+    """It exits with a status code of zero."""
+    initialise_credential_store(include_account_id=True, include_vin=True)
+    fixtures.inject_get_vehicle_details(mocked_responses, "zoe_50.1.json")
+    fixtures.inject_get_charges(
+        mocked_responses,
+        start="20201101",
+        end="20201130",
+        filename="vehicle_data/charges-zoe_50.json",
+    )
+
+    result = cli_runner.invoke(
+        __main__.main, "charge sessions --from 2020-11-01 --to 2020-11-30"
+    )
+    assert result.exit_code == 0, result.exception
+
+    expected_output = (
+        "Charge start         Charge end           Duration    Power (kW)  "
+        "  Started at    Finished at    Charge gained    Power level    Status\n"
+        "-------------------  -------------------  ----------  ------------"
+        "  ------------  -------------  ---------------  -------------  --------\n"
+        "2022-03-16 03:02:16  2022-03-16 05:01:58  1:59:42                 "
+        "  62 %          62 %                                           error\n"
+        "2022-03-16 21:18:42  2022-03-16 22:50:08  1:31:26                 "
+        "                60 %                                           error\n"
+        "2022-03-17 02:01:10  2022-03-17 06:02:01  4:00:51                 "
+        "                74 %                                           error\n"
+        "2022-03-18 02:01:13  2022-03-18 06:02:04  4:00:51                 "
+        "                64 %                                           error\n"
+        "2022-03-18 18:34:28  2022-03-18 18:37:57  0:03:29                 "
+        "                55 %                                           error\n"
+        "2022-03-18 18:40:37  2022-03-18 19:17:22  0:36:45                 "
+        "                89 %                                           error\n"
+        "2022-03-19 16:18:18  2022-03-19 17:36:04  1:17:46                 "
+        "                99 %                                           error\n"
+        "2022-03-20 22:21:31  2022-03-21 07:32:50  9:11:19                 "
+        "                71 %                                           error\n"
     )
     assert expected_output == result.output
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -350,14 +350,19 @@ def inject_get_hvac_sessions(
     )
 
 
-def inject_get_charges(mocked_responses: aioresponses, start: str, end: str) -> str:
+def inject_get_charges(
+    mocked_responses: aioresponses,
+    start: str,
+    end: str,
+    filename: str = "vehicle_data/charges.json",
+) -> str:
     """Inject sample charges."""
     query_string = f"{DEFAULT_QUERY_STRING}&end={end}&start={start}"
     urlpath = f"{ADAPTER_PATH}/charges?{query_string}"
     return inject_data(
         mocked_responses,
         urlpath,
-        "vehicle_data/charges.json",
+        filename,
     )
 
 

--- a/tests/fixtures/kamereon/vehicle_data/charges-zoe_50.json
+++ b/tests/fixtures/kamereon/vehicle_data/charges-zoe_50.json
@@ -1,0 +1,67 @@
+{
+  "data": {
+    "type": "Car",
+    "id": "VF1AAAAA555777999",
+    "attributes": {
+      "charges": [
+        {
+          "chargeStartDate": "2022-03-16T02:02:16Z",
+          "chargeEndDate": "2022-03-16T04:01:58Z",
+          "chargeDuration": 7182,
+          "chargeStartBatteryLevel": 62,
+          "chargeEndBatteryLevel": 62,
+          "chargeEndStatus": "error"
+        },
+        {
+          "chargeStartDate": "2022-03-16T20:18:42Z",
+          "chargeEndDate": "2022-03-16T21:50:08Z",
+          "chargeDuration": 5486,
+          "chargeEndBatteryLevel": 60,
+          "chargeEndStatus": "error"
+        },
+        {
+          "chargeStartDate": "2022-03-17T01:01:10Z",
+          "chargeEndDate": "2022-03-17T05:02:01Z",
+          "chargeDuration": 14451,
+          "chargeEndBatteryLevel": 74,
+          "chargeEndStatus": "error"
+        },
+        {
+          "chargeStartDate": "2022-03-18T01:01:13Z",
+          "chargeEndDate": "2022-03-18T05:02:04Z",
+          "chargeDuration": 14451,
+          "chargeEndBatteryLevel": 64,
+          "chargeEndStatus": "error"
+        },
+        {
+          "chargeStartDate": "2022-03-18T17:34:28Z",
+          "chargeEndDate": "2022-03-18T17:37:57Z",
+          "chargeDuration": 209,
+          "chargeEndBatteryLevel": 55,
+          "chargeEndStatus": "error"
+        },
+        {
+          "chargeStartDate": "2022-03-18T17:40:37Z",
+          "chargeEndDate": "2022-03-18T18:17:22Z",
+          "chargeDuration": 2205,
+          "chargeEndBatteryLevel": 89,
+          "chargeEndStatus": "error"
+        },
+        {
+          "chargeStartDate": "2022-03-19T15:18:18Z",
+          "chargeEndDate": "2022-03-19T16:36:04Z",
+          "chargeDuration": 4666,
+          "chargeEndBatteryLevel": 99,
+          "chargeEndStatus": "error"
+        },
+        {
+          "chargeStartDate": "2022-03-20T21:21:31Z",
+          "chargeEndDate": "2022-03-21T06:32:50Z",
+          "chargeDuration": 33079,
+          "chargeEndBatteryLevel": 71,
+          "chargeEndStatus": "error"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
It seems that Zoe50 reports durations in seconds not minutes.

Ref #562

cc @jumpjack