### PR TITLE
Bump pytest-asyncio from 0.18.3 to 0.20.1

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -117,7 +117,7 @@ def mypy(session: Session) -> None:
     args = session.posargs or ["src", "tests", "docs/conf.py"]
     session.install(".[cli]")
     session.install(
-        "mypy", "pytest", "types-dateparser", "types-tabulate", "types-tzlocal"
+        "mypy", "pytest", "types-dateparser", "types-tabulate", "types-tzlocal", "pytest-asyncio", "aioresponses"
     )
     session.run("mypy", *args)
     if not session.posargs:

--- a/noxfile.py
+++ b/noxfile.py
@@ -123,7 +123,7 @@ def mypy(session: Session) -> None:
         "types-tabulate",
         "types-tzlocal",
         "pytest-asyncio",
-        "aioresponses"
+        "aioresponses",
     )
     session.run("mypy", *args)
     if not session.posargs:

--- a/noxfile.py
+++ b/noxfile.py
@@ -117,7 +117,13 @@ def mypy(session: Session) -> None:
     args = session.posargs or ["src", "tests", "docs/conf.py"]
     session.install(".[cli]")
     session.install(
-        "mypy", "pytest", "types-dateparser", "types-tabulate", "types-tzlocal", "pytest-asyncio", "aioresponses"
+        "mypy",
+        "pytest",
+        "types-dateparser",
+        "types-tabulate",
+        "types-tzlocal",
+        "pytest-asyncio",
+        "aioresponses"
     )
     session.run("mypy", *args)
     if not session.posargs:

--- a/poetry.lock
+++ b/poetry.lock
@@ -753,7 +753,7 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.18.3"
+version = "0.20.1"
 description = "Pytest support for asyncio"
 category = "dev"
 optional = false
@@ -764,7 +764,7 @@ pytest = ">=6.1.0"
 typing-extensions = {version = ">=3.7.2", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["coverage (==6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (==0.931)", "pytest-trio (>=0.7.0)"]
+testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "pytest-cov"
@@ -1268,7 +1268,7 @@ cli = ["click", "tabulate", "dateparser"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<4.0"
-content-hash = "73331ef3850c47e59d1421f3c20b4ab1e07914369589de147aa4438acd13def6"
+content-hash = "cf2f429e0e29e9387c327d19aaee4a324a423cc25962b29b4bb15da24acfc349"
 
 [metadata.files]
 aiohttp = [
@@ -1845,9 +1845,8 @@ pytest = [
     {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
 ]
 pytest-asyncio = [
-    {file = "pytest-asyncio-0.18.3.tar.gz", hash = "sha256:7659bdb0a9eb9c6e3ef992eef11a2b3e69697800ad02fb06374a210d85b29f91"},
-    {file = "pytest_asyncio-0.18.3-1-py3-none-any.whl", hash = "sha256:16cf40bdf2b4fb7fc8e4b82bd05ce3fbcd454cbf7b92afc445fe299dabb88213"},
-    {file = "pytest_asyncio-0.18.3-py3-none-any.whl", hash = "sha256:8fafa6c52161addfd41ee7ab35f11836c5a16ec208f93ee388f752bea3493a84"},
+    {file = "pytest-asyncio-0.20.1.tar.gz", hash = "sha256:626699de2a747611f3eeb64168b3575f70439b06c3d0206e6ceaeeb956e65519"},
+    {file = "pytest_asyncio-0.20.1-py3-none-any.whl", hash = "sha256:2c85a835df33fda40fe3973b451e0c194ca11bc2c007eabff90bb3d156fc172b"},
 ]
 pytest-cov = [
     {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
 module = [
-    "aioresponses",
+    "aioresponses.core",
     "pytest_asyncio"
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
 module = [
+    "aioresponses",
     "aioresponses.core",
     "pytest_asyncio"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,10 @@ warn_unused_configs = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
-module = 'aioresponses.*'
+module = [
+    "aioresponses",
+    "pytest_asyncio"
+]
 ignore_missing_imports = true
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ cli = ["click", "tabulate", "dateparser"]
 [tool.poetry.scripts]
 renault-api = "renault_api.cli.__main__:main"
 
+[tool.poetry.group.dev.dependencies]
+pytest-asyncio = ">=0.20.1"
+
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,7 @@ warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
 module = [
-    "aioresponses",
-    "aioresponses.core",
+    "aioresponses.*",
     "pytest_asyncio"
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,10 +97,7 @@ warn_unused_configs = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
-module = [
-    "aioresponses.*",
-    "pytest_asyncio"
-]
+module = "aioresponses.*"
 ignore_missing_imports = true
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ warn_unused_configs = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
-module = "aioresponses.*"
+module = 'aioresponses.*'
 ignore_missing_imports = true
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ pre-commit-hooks = "^4.3.0"
 sphinx-rtd-theme = "^1.0.0"
 sphinx-click = "^4.3.0"
 Pygments = "^2.13.0"
-pytest-asyncio = "^0.18.3"
+pytest-asyncio = "^0.20.1"
 aioresponses = "^0.7.3"
 pytest-cov = "^4.0.0"
 #ensure urllib3 is greater than 1.26.5 to account for CVE-2021-33503
@@ -63,9 +63,6 @@ cli = ["click", "tabulate", "dateparser"]
 
 [tool.poetry.scripts]
 renault-api = "renault_api.cli.__main__:main"
-
-[tool.poetry.group.dev.dependencies]
-pytest-asyncio = ">=0.20.1"
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,13 +11,14 @@ from typing import Generator
 from typing import Optional
 
 import pytest
+import pytest_asyncio
 from _pytest.monkeypatch import MonkeyPatch
 from aiohttp.client import ClientSession
 from aioresponses import aioresponses
 from click.testing import CliRunner
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def websession() -> AsyncGenerator[ClientSession, None]:
     """Fixture for generating ClientSession."""
     async with ClientSession() as aiohttp_session:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ async def websession() -> AsyncGenerator[ClientSession, None]:
 
 
 @pytest.fixture(autouse=True)
-def mocked_responses() -> aioresponses:
+def mocked_responses() -> Generator[aioresponses, None, None]:
     """Fixture for mocking aiohttp responses."""
     with aioresponses() as m:
         yield m
@@ -83,7 +83,7 @@ def create_aiohttp_closed_event(
     transports = 0
     all_is_lost = asyncio.Event()
 
-    def connection_lost(exc, orig_lost):  # type: ignore
+    def connection_lost(exc, orig_lost):  # type: ignore[no-untyped-def]
         nonlocal transports
 
         try:
@@ -93,7 +93,7 @@ def create_aiohttp_closed_event(
             if transports == 0:
                 all_is_lost.set()
 
-    def eof_received(orig_eof_received):  # type: ignore
+    def eof_received(orig_eof_received):  # type: ignore[no-untyped-def]
         try:
             orig_eof_received()
         except AttributeError:
@@ -101,7 +101,7 @@ def create_aiohttp_closed_event(
             # _app_protocol and _transport are set to None.
             pass
 
-    for conn in session.connector._conns.values():  # type: ignore
+    for conn in session.connector._conns.values():  # type: ignore[no-untyped-def]
         for handler, _ in conn:
             proto = getattr(handler.transport, "_ssl_protocol", None)
             if proto is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ async def websession() -> AsyncGenerator[ClientSession, None]:
 @pytest.fixture(autouse=True)
 def mocked_responses() -> Generator[aioresponses, None, None]:
     """Fixture for mocking aiohttp responses."""
-    with aioresponses() as m:
+    with aioresponses() as m:  # type: ignore[no-untyped-call]
         yield m
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def create_aiohttp_closed_event(
             # _app_protocol and _transport are set to None.
             pass
 
-    for conn in session.connector._conns.values():  # type: ignore[no-untyped-def]
+    for conn in session.connector._conns.values():  # type: ignore[union-attr]
         for handler, _ in conn:
             proto = getattr(handler.transport, "_ssl_protocol", None)
             if proto is None:


### PR DESCRIPTION
Fix pytest fixture definition

This is currently preventing the update to the latest pytest_asyncio

See https://github.com/pytest-dev/pytest-asyncio/issues/293