### PR TITLE
Add Mégane E-TECH vehicle

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -64,6 +64,11 @@ VEHICLE_SPECIFICATIONS: Dict[str, Dict[str, Any]] = {
     "XBG1VE": {  # DACIA SPRING
         "control-charge-via-kcm": True,
     },
+    "XCB1VE": {  # MEGANE E-TECH
+        "reports-in-watts": True,
+        "reports-charge-session-durations-in-minutes": True,
+        "support-endpoint-lock-status": False,
+    },
 }
 
 GATEWAY_SPECIFICATIONS: Dict[str, Dict[str, Any]] = {
@@ -71,6 +76,11 @@ GATEWAY_SPECIFICATIONS: Dict[str, Dict[str, Any]] = {
         "reports-charge-session-durations-in-minutes": True,
         "reports-in-watts": True,
         "support-endpoint-location": False,
+        "support-endpoint-lock-status": False,
+    },
+    "AVN": {  # MEGANE E-TECH
+        "reports-in-watts": True,
+        "reports-charge-session-durations-in-minutes": True,
         "support-endpoint-lock-status": False,
     },
 }

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -65,8 +65,6 @@ VEHICLE_SPECIFICATIONS: Dict[str, Dict[str, Any]] = {
         "control-charge-via-kcm": True,
     },
     "XCB1VE": {  # MEGANE E-TECH
-        "reports-in-watts": True,
-        "reports-charge-session-durations-in-minutes": True,
         "support-endpoint-lock-status": False,
     },
 }

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -78,11 +78,6 @@ GATEWAY_SPECIFICATIONS: Dict[str, Dict[str, Any]] = {
         "support-endpoint-location": False,
         "support-endpoint-lock-status": False,
     },
-    "AVN": {  # MEGANE E-TECH
-        "reports-in-watts": True,
-        "reports-charge-session-durations-in-minutes": True,
-        "support-endpoint-lock-status": False,
-    },
 }
 
 

--- a/tests/fixtures/kamereon/vehicles/megane_e-tech.1.json
+++ b/tests/fixtures/kamereon/vehicles/megane_e-tech.1.json
@@ -1,0 +1,117 @@
+{
+  "accountId": "account-id-megane",
+  "country": "FR",
+  "vehicleLinks": [
+    {
+      "brand": "RENAULT",
+      "vin": "VF1AAAAA123987456",
+      "status": "ACTIVE",
+      "linkType": "OWNER",
+      "garageBrand": "renault",
+      "startDate": "2022-08-31",
+      "createdDate": "2022-08-31T08:06:05.425594Z",
+      "lastModifiedDate": "2022-11-01T21:12:28.863554Z",
+      "ownershipStartDate": "2022-08-26",
+      "cancellationReason": {},
+      "preferredDealer": {
+        "dealerId": "00000701_001",
+        "dealerName": "RENAULT NANTES - GROUPE JEAN ROUYER",
+        "brand": "RENAULT",
+        "createdDate": "2022-09-11T18:52:15.089690388Z",
+        "lastModifiedDate": "2022-09-11T18:52:15.089690388Z"
+      },
+      "connectedDriver": {
+        "role": "MAIN_DRIVER",
+        "createdDate": "2022-09-02T18:09:47.429134080Z",
+        "lastModifiedDate": "2022-09-02T18:09:47.429134080Z"
+      },
+      "vehicleDetails": {
+        "vin": "VF1AAAAA123987456",
+        "registrationDate": "2022-08-26",
+        "firstRegistrationDate": "2022-08-26",
+        "engineType": "6AM",
+        "engineRatio": "402",
+        "modelSCR": "",
+        "deliveryCountry": {
+          "code": "FR",
+          "label": "FRANCE"
+        },
+        "family": {
+          "code": "XCB",
+          "label": "XCB FAMILY",
+          "group": "007"
+        },
+        "tcu": {
+          "code": "AIVCT",
+          "label": "WITH AIVC CONNECTION UNIT",
+          "group": "E70"
+        },
+        "navigationAssistanceLevel": {
+          "code": "",
+          "label": "",
+          "group": ""
+        },
+        "battery": {
+          "code": "BTBAE",
+          "label": "BTBAE BATTERY",
+          "group": "968"
+        },
+        "radioType": {
+          "code": "NA448",
+          "label": "IVI2 FULL PREM DAB",
+          "group": "425"
+        },
+        "registrationCountry": {
+          "code": "FR"
+        },
+        "brand": {
+          "label": "RENAULT"
+        },
+        "model": {
+          "code": "XCB1VE",
+          "label": "MEGANE E-TECH",
+          "group": "971"
+        },
+        "gearbox": {
+          "code": "1EVGB",
+          "label": "REDUCER FOR ELECTRIC MOTOR",
+          "group": "427"
+        },
+        "version": {
+          "code": "2PRE M J1 L"
+        },
+        "energy": {
+          "code": "ELECX",
+          "label": "ELECTRICITY",
+          "group": "019"
+        },
+        "registrationNumber": "REG-NUMBER",
+        "vcd": "PAVEH/XCB/BCB/EA4/J1/ELECX/LHDG/TEMP/2WDRV/BEMBK/ACC02/00ABS/ACD03/STDRF/HTRWI/WFURP/CLK00/RVX07/1RVLG/FFGL2/SDLGT/RAL20/FSBAJ/SPADP/FAB02/NOCNV/LRSCO/LRS02/HAR04/RHR03/FSE06/RSE00/BIXUF/NTIBC/KMETR/TPRM2/SDSGL/NOSTK/SABG5/LEDCO/ESCHS/PALAW/SPBDA/M3CA3/NOADS/DB4C0/NOAGR/LRSW0/OSEWA/RVIAT/TRSV0/NBRVX/FWL1T/RWL1T/NOOSW/REPKT/HTS02/00FRA/BRA03/AJSW2/HSTPL/SBR05/RMSB3/NA448/1EVGB/ASOC2/EVAU2/RIM09/TYSUM/ISOFI/EPER0/HR11M/SLCCA/NOATD/CPTC0/CHGS4/TL01A/BDPRO/NOADT/ABCXL/ELC1/NOETC/NOLSV/NOFEX/M2021/PHAS1/NOLTD/NOATY/NOHYB/60K0B/BTBAE/VEC088/XCB1VE/NB003/6AM/SFANT/ADR00/LKA05/PSFT0/BIHT0/NODUP/NOWAP/NOCCH/AMLT0/DRL02/RCALL/PURFR/TBI00/MET05/BSD02/ECMD0/NRCAR/M2CA0/AIVCT/GSI00/TP369/TSGNE/2BCOL/ITP15/MDMOD/PXA00/PXB00/PIG02/HTSW0/DAALT/WICH0/EV1GA1/SMOSP/NOWMC/FCOWA/C1AHS/NOPRA/VSPTA/1234Y/NOLIE/NOLII/NOWFI/AEB09/WOSRE/PRAHL/SPMIR/RRCAM/NORCT/DTRNI",
+        "assets": [
+          {
+            "assetType": "PICTURE",
+            "renditions": [
+              {
+                "resolutionType": "ONE_MYRENAULT_LARGE",
+                "url": "https://3dv.renault.com/ImageFromBookmark?configuration=BCB%2FEA4%2FLHDG%2FACD03%2FSTDRF%2FWFURP%2FRVX07%2FRAL20%2FLRS02%2FFSE06%2FBIXUF%2FLEDCO%2FPALAW%2FSPBDA%2FLRSW0%2FRVIAT%2FTRSV0%2FAJSW2%2FNA448%2FASOC2%2FRIM09%2FSLCCA%2FNOATD%2FBDPRO%2FNOETC%2FM2021%2FNB003%2FSFANT%2FADR00%2FNODUP%2FNOWAP%2FRCALL%2FBSD02%2F2BCOL%2FITP15%2FMDMOD%2FPXA00%2FPXB00%2FPIG02%2FHTSW0%2FNOLII%2FRRCAM%2FDTRNI&databaseId=08eb195d-c2b1-42e8-910c-6c350668b3b9&bookmarkSet=RSITE&bookmark=EXT_34_DESSUS&profile=HELIOS_OWNERSERVICES_LARGE"
+              },
+              {
+                "resolutionType": "ONE_MYRENAULT_SMALL",
+                "url": "https://3dv.renault.com/ImageFromBookmark?configuration=BCB%2FEA4%2FLHDG%2FACD03%2FSTDRF%2FWFURP%2FRVX07%2FRAL20%2FLRS02%2FFSE06%2FBIXUF%2FLEDCO%2FPALAW%2FSPBDA%2FLRSW0%2FRVIAT%2FTRSV0%2FAJSW2%2FNA448%2FASOC2%2FRIM09%2FSLCCA%2FNOATD%2FBDPRO%2FNOETC%2FM2021%2FNB003%2FSFANT%2FADR00%2FNODUP%2FNOWAP%2FRCALL%2FBSD02%2F2BCOL%2FITP15%2FMDMOD%2FPXA00%2FPXB00%2FPIG02%2FHTSW0%2FNOLII%2FRRCAM%2FDTRNI&databaseId=08eb195d-c2b1-42e8-910c-6c350668b3b9&bookmarkSet=RSITE&bookmark=EXT_34_DESSUS&profile=HELIOS_OWNERSERVICES_SMALL_V2"
+              }
+            ]
+          }
+        ],
+        "yearsOfMaintenance": 12,
+        "connectivityTechnology": "NONE",
+        "easyConnectStore": false,
+        "electrical": true,
+        "rlinkStore": false,
+        "deliveryDate": "2022-09-07",
+        "retrievedFromDhs": false,
+        "engineEnergyType": "ELEC",
+        "radioCode": "1234"
+      }
+    }
+  ]
+}

--- a/tests/kamereon/test_kamereon_vehicles.py
+++ b/tests/kamereon/test_kamereon_vehicles.py
@@ -121,7 +121,7 @@ EXPECTED_SPECS = {
         "get_energy_code": "ELECX",
         "get_model_code": "XCB1VE",
         "get_model_label": "MEGANE E-TECH",
-        "reports_charging_power_in_watts": True,
+        "reports_charging_power_in_watts": False,
         "uses_electricity": True,
         "uses_fuel": False,
         "supports-hvac-status": True,

--- a/tests/kamereon/test_kamereon_vehicles.py
+++ b/tests/kamereon/test_kamereon_vehicles.py
@@ -116,6 +116,18 @@ EXPECTED_SPECS = {
         "supports-location": True,
         "charge-uses-kcm": True,
     },
+    "megane_e-tech.1.json": {
+        "get_brand_label": "RENAULT",
+        "get_energy_code": "ELECX",
+        "get_model_code": "XCB1VE",
+        "get_model_label": "MEGANE E-TECH",
+        "reports_charging_power_in_watts": True,
+        "uses_electricity": True,
+        "uses_fuel": False,
+        "supports-hvac-status": True,
+        "supports-location": True,
+        "charge-uses-kcm": False,
+    },
 }
 
 


### PR DESCRIPTION
This adds the sample + unit tests for the new Renalt Mégane E-TECH

FYI, the instant power seems to be the maximum W (or kW) power the car can take, based on the data I get when charging on a 7.2 kW charger. Looks very much like the charging curve we have been seeing for this car:

![Screenshot 2022-10-29 at 10-15-31 History – Home Assistant](https://user-images.githubusercontent.com/2082759/199422516-a9597021-c9b0-4f48-8c46-417052125d25.png)
