### PR TITLE
Adjust error handling for Gigya JSONDecodeError

### DIFF
--- a/src/renault_api/gigya/__init__.py
+++ b/src/renault_api/gigya/__init__.py
@@ -1,5 +1,6 @@
 """Gigya API."""
 import logging
+from json import JSONDecodeError
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -9,6 +10,7 @@ from marshmallow.schema import Schema
 
 from . import models
 from . import schemas
+from .exceptions import GigyaException
 
 GIGYA_JWT = "gigya_jwt"
 GIGYA_LOGIN_TOKEN = "gigya_login_token"  # noqa: S105
@@ -35,7 +37,10 @@ async def request(
         #    url,
         #    response_text,
         # )
-        gigya_response: models.GigyaResponse = schema.loads(response_text)
+        try:
+            gigya_response: models.GigyaResponse = schema.loads(response_text)
+        except JSONDecodeError as err:
+            raise GigyaException("Gigya responded with invalid JSON") from err
         # Check for Gigya error
         gigya_response.raise_for_error_code()
         # Check for HTTP error

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -5,14 +5,6 @@ import datetime
 import json
 from glob import glob
 from os import path
-from tests.const import REDACTED
-from tests.const import TEST_ACCOUNT_ID
-from tests.const import TEST_COUNTRY
-from tests.const import TEST_GIGYA_URL
-from tests.const import TEST_KAMEREON_URL
-from tests.const import TEST_PERSON_ID
-from tests.const import TEST_VIN
-from tests.const import TO_REDACT
 from typing import Any
 from typing import List
 from typing import Mapping
@@ -21,6 +13,14 @@ from typing import Optional
 import jwt
 from aioresponses import aioresponses
 from marshmallow.schema import Schema
+from tests.const import REDACTED
+from tests.const import TEST_ACCOUNT_ID
+from tests.const import TEST_COUNTRY
+from tests.const import TEST_GIGYA_URL
+from tests.const import TEST_KAMEREON_URL
+from tests.const import TEST_PERSON_ID
+from tests.const import TEST_VIN
+from tests.const import TO_REDACT
 
 GIGYA_FIXTURE_PATH = "tests/fixtures/gigya"
 KAMEREON_FIXTURE_PATH = "tests/fixtures/kamereon"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -5,14 +5,6 @@ import datetime
 import json
 from glob import glob
 from os import path
-from typing import Any
-from typing import List
-from typing import Mapping
-from typing import Optional
-
-import jwt
-from aioresponses import aioresponses
-from marshmallow.schema import Schema
 from tests.const import REDACTED
 from tests.const import TEST_ACCOUNT_ID
 from tests.const import TEST_COUNTRY
@@ -21,6 +13,14 @@ from tests.const import TEST_KAMEREON_URL
 from tests.const import TEST_PERSON_ID
 from tests.const import TEST_VIN
 from tests.const import TO_REDACT
+from typing import Any
+from typing import List
+from typing import Mapping
+from typing import Optional
+
+import jwt
+from aioresponses import aioresponses
+from marshmallow.schema import Schema
 
 GIGYA_FIXTURE_PATH = "tests/fixtures/gigya"
 KAMEREON_FIXTURE_PATH = "tests/fixtures/kamereon"
@@ -108,6 +108,15 @@ def inject_gigya_login(mocked_responses: aioresponses) -> str:
         mocked_responses,
         "accounts.login",
         "login.json",
+    )
+
+
+def inject_gigya_login_invalid(mocked_responses: aioresponses) -> str:
+    """Inject Gigya login data."""
+    return inject_gigya(
+        mocked_responses,
+        "accounts.login",
+        "login_invalid.txt",
     )
 
 

--- a/tests/gigya/test_gigya.py
+++ b/tests/gigya/test_gigya.py
@@ -1,4 +1,7 @@
 """Tests for Gigya API."""
+import aiohttp
+import pytest
+from aioresponses import aioresponses
 from tests import fixtures
 from tests.const import TEST_GIGYA_APIKEY
 from tests.const import TEST_GIGYA_URL
@@ -6,10 +9,6 @@ from tests.const import TEST_LOGIN_TOKEN
 from tests.const import TEST_PASSWORD
 from tests.const import TEST_PERSON_ID
 from tests.const import TEST_USERNAME
-
-import aiohttp
-import pytest
-from aioresponses import aioresponses
 
 from renault_api import gigya
 

--- a/tests/gigya/test_gigya.py
+++ b/tests/gigya/test_gigya.py
@@ -1,7 +1,4 @@
 """Tests for Gigya API."""
-import aiohttp
-import pytest
-from aioresponses import aioresponses
 from tests import fixtures
 from tests.const import TEST_GIGYA_APIKEY
 from tests.const import TEST_GIGYA_URL
@@ -9,6 +6,10 @@ from tests.const import TEST_LOGIN_TOKEN
 from tests.const import TEST_PASSWORD
 from tests.const import TEST_PERSON_ID
 from tests.const import TEST_USERNAME
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
 
 from renault_api import gigya
 
@@ -28,6 +29,23 @@ async def test_login(
         TEST_PASSWORD,
     )
     assert response.get_session_cookie() == TEST_LOGIN_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_login_error(
+    websession: aiohttp.ClientSession, mocked_responses: aioresponses
+) -> None:
+    """Test login response."""
+    fixtures.inject_gigya_login_invalid(mocked_responses)
+
+    with pytest.raises(gigya.exceptions.GigyaException):
+        await gigya.login(
+            websession,
+            TEST_GIGYA_URL,
+            TEST_GIGYA_APIKEY,
+            TEST_USERNAME,
+            TEST_PASSWORD,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 382, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/renault/__init__.py", line 28, in async_setup_entry
    await renault_hub.async_initialise(config_entry)
  File "/usr/src/homeassistant/homeassistant/components/renault/renault_hub.py", line 59, in async_initialise
    vehicles = await self._account.get_vehicles()
  File "/usr/local/lib/python3.10/site-packages/renault_api/renault_account.py", line 62, in get_vehicles
    return await self.session.get_account_vehicles(
  File "/usr/local/lib/python3.10/site-packages/renault_api/renault_session.py", line 192, in get_account_vehicles
    gigya_jwt=await self._get_jwt(),
  File "/usr/local/lib/python3.10/site-packages/renault_api/renault_session.py", line 142, in _get_jwt
    response = await gigya.get_jwt(
  File "/usr/local/lib/python3.10/site-packages/renault_api/gigya/__init__.py", line 102, in get_jwt
    await request(
  File "/usr/local/lib/python3.10/site-packages/renault_api/gigya/__init__.py", line 38, in request
    gigya_response: models.GigyaResponse = schema.loads(response_text)
  File "/usr/local/lib/python3.10/site-packages/marshmallow/schema.py", line 755, in loads
    data = self.opts.render_module.loads(json_data, **kwargs)
  File "/usr/local/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```