### PR TITLE
Fix for failing tests on CI with no locale set

### DIFF
--- a/tests/cli/test_account.py
+++ b/tests/cli/test_account.py
@@ -52,8 +52,11 @@ def test_list_vehicles_prompt(
     )
     assert result.exit_code == 0, result.exception
 
+    default_locale = getdefaultlocale()[0]
+    prompt_default = f" [{default_locale}]" if default_locale else ""
+
     expected_output = (
-        f"Please select a locale [{getdefaultlocale()[0]}]: {TEST_LOCALE}\n"
+        f"Please select a locale{prompt_default}: {TEST_LOCALE}\n"
         "Do you want to save the locale to the credential store? [y/N]: N\n"
         "\n"
         f"User: {TEST_USERNAME}\n"

--- a/tests/cli/test_client.py
+++ b/tests/cli/test_client.py
@@ -34,10 +34,13 @@ def test_login_prompt(mocked_responses: aioresponses, cli_runner: CliRunner) -> 
         input=f"{TEST_USERNAME}\n{TEST_PASSWORD}\n{TEST_LOCALE}\ny",
     )
     assert result.exit_code == 0, result.exception
+    default_locale = getdefaultlocale()[0]
+    prompt_default = f" [{default_locale}]" if default_locale else ""
+
     expected_output = (
         f"User: {TEST_USERNAME}\n"
         "Password: \n"
-        f"Please select a locale [{getdefaultlocale()[0]}]: {TEST_LOCALE}\n"
+        f"Please select a locale{prompt_default}: {TEST_LOCALE}\n"
         "Do you want to save the locale to the credential store? [y/N]: y\n"
         "\n"
     )
@@ -70,9 +73,11 @@ def test_list_accounts_prompt(
         input=f"{TEST_LOCALE}\nN\n{TEST_USERNAME}\n{TEST_PASSWORD}\n",
     )
     assert result.exit_code == 0, result.exception
+    default_locale = getdefaultlocale()[0]
+    prompt_default = f" [{default_locale}]" if default_locale else ""
 
     expected_output = (
-        f"Please select a locale [{getdefaultlocale()[0]}]: {TEST_LOCALE}\n"
+        f"Please select a locale{prompt_default}: {TEST_LOCALE}\n"
         "Do you want to save the locale to the credential store? [y/N]: N\n"
         "\n"
         f"User: {TEST_USERNAME}\n"

--- a/tests/cli/test_vehicle.py
+++ b/tests/cli/test_vehicle.py
@@ -237,8 +237,11 @@ def test_vehicle_status_prompt(
     )
     assert result.exit_code == 0, result.exception
 
+    default_locale = getdefaultlocale()[0]
+    prompt_default = f" [{default_locale}]" if default_locale else ""
+
     expected_output = (
-        f"Please select a locale [{getdefaultlocale()[0]}]: {TEST_LOCALE}\n"
+        f"Please select a locale{prompt_default}: {TEST_LOCALE}\n"
         "Do you want to save the locale to the credential store? [y/N]: N\n"
         "\n"
         f"User: {TEST_USERNAME}\n"


### PR DESCRIPTION
Update the tests so they support running on a system where Python is not able to determine the default locale.

Output of a failed build with the default locale is not set is here:
https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/python-renault-api.html