### PR TITLE
Fix the CLI test for click 8.2

### DIFF
--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 from collections.abc import Generator
 from datetime import datetime
+from importlib import metadata as imp_metadata
 from typing import Any
 
 from _pytest.fixtures import fixture
@@ -42,8 +43,12 @@ def patch_datetime(monkeypatch: MonkeyPatch) -> Generator[None, None, None]:
 
 def test_main_succeeds(cli_runner: CliRunner) -> None:
     """It exits with a status code of zero."""
+    click_version_str = imp_metadata.version("click")
+    click_version_parts = tuple(int(part) for part in click_version_str.split(".")[:2])
     result = cli_runner.invoke(__main__.main)
-    assert result.exit_code == 0, result.exception
+    assert result.exit_code == (
+        2 if click_version_parts >= (8, 2) else 0
+    ), result.exception
 
 
 def test_debug(cli_runner: CliRunner, caplog: Any) -> None:


### PR DESCRIPTION
Hi,

First of all, thanks a lot for writing and maintaining renault-api!

I am the maintainer of the Debian package of click; I uploaded click 8.2.0 to the Debian unstable suite a couple of days ago, and it turns out that might have been a bit premature, since there are a couple of incompatibilities that affect several other Python libraries. 

What do you think about this change? In click 8.2, running a program without specifying a subcommand still displays the usage message, but exits with code 2 instead of 0.

Thanks in advance for your time, and keep up the great work!