### PR TITLE
Added V2L ChargeStatus to Kamereon enums

### DIFF
--- a/src/renault_api/kamereon/enums.py
+++ b/src/renault_api/kamereon/enums.py
@@ -12,6 +12,7 @@ class ChargeState(Enum):
     WAITING_FOR_CURRENT_CHARGE = 0.3
     ENERGY_FLAP_OPENED = 0.4
     CHARGE_IN_PROGRESS = 1.0
+    V2L_CONNECTED = -1.4
     # This next is more accurately "not charging" (<= ZE40) or "error" (ZE50).
     CHARGE_ERROR = -1.0
     UNAVAILABLE = -1.1

--- a/src/renault_api/kamereon/enums.py
+++ b/src/renault_api/kamereon/enums.py
@@ -12,6 +12,9 @@ class ChargeState(Enum):
     WAITING_FOR_CURRENT_CHARGE = 0.3
     ENERGY_FLAP_OPENED = 0.4
     CHARGE_IN_PROGRESS = 1.0
+    V2G_CHARGING_WAITING = -1.3
+    V2G_CHARGING_NORMAL = -1.6
+    V2G_DISCHARGING = -1.5
     V2L_CONNECTED = -1.4
     # This next is more accurately "not charging" (<= ZE40) or "error" (ZE50).
     CHARGE_ERROR = -1.0

--- a/src/renault_api/kamereon/enums.py
+++ b/src/renault_api/kamereon/enums.py
@@ -13,9 +13,9 @@ class ChargeState(Enum):
     ENERGY_FLAP_OPENED = 0.4
     CHARGE_IN_PROGRESS = 1.0
     V2G_CHARGING_WAITING = -1.3
-    V2G_CHARGING_NORMAL = -1.6
-    V2G_DISCHARGING = -1.5
     V2L_CONNECTED = -1.4
+    V2G_DISCHARGING = -1.5
+    V2G_CHARGING_NORMAL = -1.6
     # This next is more accurately "not charging" (<= ZE40) or "error" (ZE50).
     CHARGE_ERROR = -1.0
     UNAVAILABLE = -1.1


### PR DESCRIPTION
The Dacia Spring has a V2L adapter with its corresponding state and the library was failing with a 
`Error: Unable to convert '-1.4' to ChargeState.` error with the adapter connected.

I added the value to the enum list. As a confirmation, here's a screenshot of the app with the V2L connected
![Screenshot_20250320-114512_edited](https://github.com/user-attachments/assets/d075e653-ecc2-4d21-bc97-3c08658c5b1e)
