### PR TITLE
ensure poetry plugin is installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ classifiers = [
 [tool.poetry.urls]
 Changelog = "https://github.com/hacf-fr/renault-api/releases"
 
+[tool.poetry.requires-plugins]
+poetry-plugin-export = ">=1.8"
+
 [tool.poetry.dependencies]
 python = ">=3.9.2,<4.0" # 3.9.0, 3.9.1 have issues with cryptography https://github.com/pyca/cryptography/pull/12045
 # Warning: as of 2024-04-23, aiohttp is pinned to 3.9.5 on HA-core


### PR DESCRIPTION
I wanted to work on #1354.

Step 1 was installing this repo locally and getting the tests to run.

I installed a recent version of poetry. (once I saw it was a requirement for this project I went to the poetry docs)
Only after installation did I see the warning about incompatibilities.

Then, to see if that works anyway, since [the version that's used in the docs](https://github.com/hacf-fr/renault-api/blob/main/CONTRIBUTING.rst) is [5 years old at this point](https://github.com/python-poetry/poetry/releases/tag/1.0.10) and the incompatibilities the docs speak of might have been fixed in that time.

I added a line in the `pyproject` that the [`nox-poetry` docs](https://github.com/cjolowicz/nox-poetry) recommend for compatibility with poetry 2 that wasn't there already.

I am currently running `nox` (it takes so long, it's been going for over 5 minutes at this point) and everything appears to be working.

Poetry1 will probably still work since this ensures a plugin is installed that ships with poetry1 by default