### PR TITLE
Add vehicle method to get soc limits

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -556,6 +556,15 @@ class KamereonVehicleBatteryStatusData(KamereonVehicleDataAttributes):
 
 
 @dataclass
+class KamereonVehicleBatterySocData(KamereonVehicleDataAttributes):
+    """Kamereon vehicle battery state of charge limits data."""
+
+    lastEnergyUpdateTimestamp: Optional[str]
+    socMin: Optional[int]
+    socTarget: Optional[int]
+
+
+@dataclass
 class KamereonVehicleTyrePressureData(KamereonVehicleDataAttributes):
     """Kamereon vehicle tyre-pressure data."""
 

--- a/src/renault_api/kamereon/schemas.py
+++ b/src/renault_api/kamereon/schemas.py
@@ -37,6 +37,10 @@ KamereonVehicleBatteryStatusDataSchema = marshmallow_dataclass.class_schema(
     models.KamereonVehicleBatteryStatusData, base_schema=BaseSchema
 )()
 
+KamereonVehicleBatterySocDataSchema = marshmallow_dataclass.class_schema(
+    models.KamereonVehicleBatterySocData, base_schema=BaseSchema
+)()
+
 KamereonVehicleTyrePressureDataSchema = marshmallow_dataclass.class_schema(
     models.KamereonVehicleTyrePressureData, base_schema=BaseSchema
 )()

--- a/src/renault_api/renault_vehicle.py
+++ b/src/renault_api/renault_vehicle.py
@@ -197,7 +197,7 @@ class RenaultVehicle:
         response = await self._get_vehicle_data("soc-levels")
         return cast(
             models.KamereonVehicleBatterySocData,
-            response.get_attributes(schemas.KamereonVehicleBatterySocDataSchema)
+            response.get_attributes(schemas.KamereonVehicleBatterySocDataSchema),
         )
 
     async def get_tyre_pressure(self) -> models.KamereonVehicleTyrePressureData:

--- a/src/renault_api/renault_vehicle.py
+++ b/src/renault_api/renault_vehicle.py
@@ -192,6 +192,14 @@ class RenaultVehicle:
             response.get_attributes(schemas.KamereonVehicleBatteryStatusDataSchema),
         )
 
+    async def get_battery_soc(self) -> models.KamereonVehicleBatterySocData:
+        """Get vehicle battery state of charge limits"""
+        response = await self._get_vehicle_data("soc-levels")
+        return cast(
+            models.KamereonVehicleBatterySocData,
+            response.get_attributes(schemas.KamereonVehicleBatterySocDataSchema)
+        )
+
     async def get_tyre_pressure(self) -> models.KamereonVehicleTyrePressureData:
         """Get vehicle tyre pressure."""
         response = await self._get_vehicle_data("pressure")

--- a/src/renault_api/renault_vehicle.py
+++ b/src/renault_api/renault_vehicle.py
@@ -197,7 +197,7 @@ class RenaultVehicle:
         response = await self._get_vehicle_data("soc-levels")
         return cast(
             models.KamereonVehicleBatterySocData,
-            response.get_attributes(schemas.KamereonVehicleBatterySocDataSchema),
+            schemas.KamereonVehicleBatterySocDataSchema.load(response.raw_data),
         )
 
     async def get_tyre_pressure(self) -> models.KamereonVehicleTyrePressureData:

--- a/tests/__snapshots__/test_renault_vehicle.ambr
+++ b/tests/__snapshots__/test_renault_vehicle.ambr
@@ -1,6 +1,6 @@
 # serializer version: 1
 # name: test_get_battery_soc
-  KamereonVehicleBatterySocData(raw_data={}, lastEnergyUpdateTimestamp=None, socMin=None, socTarget=None)
+  KamereonVehicleBatterySocData(raw_data={'lastEnergyUpdateTimestamp': '2025-04-18T06:51:09Z', 'socMin': 20, 'socTarget': 80}, lastEnergyUpdateTimestamp='2025-04-18T06:51:09Z', socMin=20, socTarget=80)
 # ---
 # name: test_get_charge_schedule
   dict({

--- a/tests/__snapshots__/test_renault_vehicle.ambr
+++ b/tests/__snapshots__/test_renault_vehicle.ambr
@@ -1,4 +1,7 @@
 # serializer version: 1
+# name: test_get_battery_soc
+  KamereonVehicleBatterySocData(raw_data={}, lastEnergyUpdateTimestamp=None, socMin=None, socTarget=None)
+# ---
 # name: test_get_charge_schedule
   dict({
     'calendar': dict({

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -277,6 +277,19 @@ def inject_get_battery_status(
     )
 
 
+def inject_get_battery_soc(
+    mocked_responses: aioresponses,
+    filename: str = "vehicle_kcm_data/ev-soc-levels.json",
+) -> str:
+    """Inject sample battery state of charge limits."""
+    urlpath = f"{KCM_ADAPTER_PATH}/ev/soc-levels?{DEFAULT_QUERY_STRING}"
+    return inject_data(
+        mocked_responses,
+        urlpath,
+        filename,
+    )
+
+
 def inject_get_tyre_pressure(
     mocked_responses: aioresponses, filename: str = "vehicle_data/pressure.json"
 ) -> str:

--- a/tests/test_renault_vehicle.py
+++ b/tests/test_renault_vehicle.py
@@ -102,6 +102,16 @@ async def test_get_battery_status(
 
 
 @pytest.mark.asyncio
+async def test_get_battery_soc(
+    vehicle: RenaultVehicle, mocked_responses: aioresponses, snapshot: SnapshotAssertion
+) -> None:
+    """Test get_battery_soc."""
+    fixtures.inject_get_vehicle_details(mocked_responses, "renault_5.1.json")
+    fixtures.inject_get_battery_soc(mocked_responses)
+    assert await vehicle.get_battery_soc() == snapshot
+
+
+@pytest.mark.asyncio
 async def test_get_tyre_pressure(
     vehicle: RenaultVehicle, mocked_responses: aioresponses
 ) -> None:


### PR DESCRIPTION
Added a vehicle method to use the `soc-levels` endpoint.

In my app I'm currently doing
```py
    data = await vehicle._get_vehicle_data("soc-levels")
```

Now I'll be able to not use the private method and do this instead.
```py
data = await vehicle.get_battery_soc()
```

Also wanted to be more complete this time, so I followed the patterns I saw in this codebase to add a type for the return value.