### PR TITLE
Document XJL2TR (Arkana)

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -345,7 +345,7 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "charge-mode": None,  # Reason: "err.func.wired.forbidden"
         "charge-schedule": None,  # Reason: "err.func.wired.forbidden"
         "charging-settings": None,  # Reason: "err.func.wired.forbidden"
-        "hvac-status": None, # Reason: "err.func.wired.notFound"
+        "hvac-status": None,  # Reason: "err.func.wired.notFound"
         "hvac-history": None,  # Reason: "err.func.wired.not-found"
         "hvac-settings": None,  # Reason: "err.func.wired.not-found"
         "hvac-sessions": None,  # Reason: "err.func.wired.not-found"


### PR DESCRIPTION
Fixes #1822

Confirmed with Hungarian Renault support that since Arkana is not an EV, no write operations are supported and read operations are also kind of limited, but at least we have fuel economy, mileage and location.