### PR TITLE
Update documentation for XCB1VE (Megane E-TECH)

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -335,6 +335,8 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "res-state": None,
     },
     "XCB1VE": {  # MEGANE E-TECH
+        "actions/charge-start": _DEFAULT_ENDPOINTS["actions/charge-start"],
+        "actions/charge-stop": None, # Reason: err.func.wired.invalid-body-format
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
         "charge-history": None,  # Reason: "err.func.wired.not-found"
         "charge-mode": None,  # Reason: "err.func.vcps.ev.charge-mode.error"

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -336,7 +336,7 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
     },
     "XCB1VE": {  # MEGANE E-TECH
         "actions/charge-start": _DEFAULT_ENDPOINTS["actions/charge-start"],
-        "actions/charge-stop": None, # Reason: err.func.wired.invalid-body-format
+        "actions/charge-stop": None,  # Reason: err.func.wired.invalid-body-format
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
         "charge-history": None,  # Reason: "err.func.wired.not-found"
         "charge-mode": None,  # Reason: "err.func.vcps.ev.charge-mode.error"

--- a/tests/__snapshots__/test_renault_vehicle.ambr
+++ b/tests/__snapshots__/test_renault_vehicle.ambr
@@ -252,6 +252,8 @@
 # ---
 # name: test_get_endpoints[tests/fixtures/kamereon/vehicles/megane_e-tech.1.json]
   dict({
+    'actions/charge-start': EndpointDefinition(endpoint='/kca/car-adapter/v1/cars/{vin}/actions/charging-start', mode='default'),
+    'actions/charge-stop': None,
     'battery-status': EndpointDefinition(endpoint='/kca/car-adapter/v2/cars/{vin}/battery-status', mode='default'),
     'charge-history': None,
     'charge-mode': None,
@@ -271,6 +273,8 @@
 # ---
 # name: test_get_endpoints[tests/fixtures/kamereon/vehicles/megane_e-tech.2.json]
   dict({
+    'actions/charge-start': EndpointDefinition(endpoint='/kca/car-adapter/v1/cars/{vin}/actions/charging-start', mode='default'),
+    'actions/charge-stop': None,
     'battery-status': EndpointDefinition(endpoint='/kca/car-adapter/v2/cars/{vin}/battery-status', mode='default'),
     'charge-history': None,
     'charge-mode': None,


### PR DESCRIPTION
Added charge-start as the default action is working for the Megane. Blocking charge-stop as this is not working as is.