### PR TITLE
Add charge mode in progress error

### DIFF
--- a/src/renault_api/kamereon/exceptions.py
+++ b/src/renault_api/kamereon/exceptions.py
@@ -66,6 +66,12 @@ class PrivacyModeOnException(KamereonResponseException):
     pass
 
 
+class ChargeModeInProgressException(KamereonResponseException):
+    """Charge mode change in progress."""
+
+    pass
+
+
 class ForbiddenException(KamereonResponseException):
     """The access is forbidden."""
 

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -55,6 +55,10 @@ COMMON_ERRRORS: list[dict[str, Any]] = [
         "errorCode": "err.func.wired.forbidden",
         "error_type": exceptions.ForbiddenException,
     },
+    {
+        "errorCode": "409001",
+        "error_type": exceptions.ChargeModeInProgressException,
+    },
 ]
 
 VEHICLE_SPECIFICATIONS: dict[str, dict[str, Any]] = {

--- a/tests/fixtures/kamereon/error/charge_mode_inprogress.json
+++ b/tests/fixtures/kamereon/error/charge_mode_inprogress.json
@@ -1,0 +1,17 @@
+{
+  "type": "FUNCTIONAL",
+  "messages": [
+    {
+      "code": "err.func.vcps.ev.charge-mode.error",
+      "message": "A remote CHARGE_MODE is already in progress"
+    }
+  ],
+  "errors": [
+    {
+      "errorCode": "409001",
+      "errorMessage": "A remote CHARGE_MODE is already in progress",
+      "errorType": "functional",
+      "errorLevel": "error"
+    }
+  ]
+}

--- a/tests/kamereon/test_kamereon_error.py
+++ b/tests/kamereon/test_kamereon_error.py
@@ -90,6 +90,18 @@ def test_vehicle_error_not_supported() -> None:
     )
 
 
+def test_vehicle_charge_mode_inprogress() -> None:
+    """Test vehicle Charge mode change in progress response."""
+    response: models.KamereonVehicleDataResponse = fixtures.get_file_content_as_schema(
+        f"{fixtures.KAMEREON_FIXTURE_PATH}/error/charge_mode_inprogress.json",
+        schemas.KamereonVehicleDataResponseSchema,
+    )
+    with pytest.raises(exceptions.ChargeModeInProgressException) as excinfo:
+        response.raise_for_error_code()
+    assert excinfo.value.error_code == "409001"
+    assert excinfo.value.error_details == "A remote CHARGE_MODE is already in progress"
+
+
 def test_vehicle_error_privacy_on() -> None:
     """Test vehicle privacy on response."""
     response: models.KamereonVehicleDataResponse = fixtures.get_file_content_as_schema(


### PR DESCRIPTION
It looks like a change to the Renault servers have been made. When sending multiple actions/charge-set-mode too quickly it now returns an error. I have not seen this prior to last month.