### PR TITLE
Rename pause-resume endpoint definitions

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -148,14 +148,14 @@ _KCA_ALTERNATIVE_ENDPOINTS: dict[str, EndpointDefinition] = {
     ),
 }
 _KCM_ENDPOINTS: dict[str, EndpointDefinition] = {
-    "actions/charge-start": EndpointDefinition(
-        "/kcm/v1/vehicles/{vin}/charge/pause-resume", mode="kcm"
+    "actions/charge-start-via-pause-resume": EndpointDefinition(
+        "/kcm/v1/vehicles/{vin}/charge/pause-resume", mode="kcm-pause-resume"
     ),
     "actions/charge-start-via-settings": EndpointDefinition(
         "/kcm/v1/vehicles/{vin}/ev/settings", mode="kcm-settings"
     ),
-    "actions/charge-stop": EndpointDefinition(
-        "/kcm/v1/vehicles/{vin}/charge/pause-resume", mode="kcm"
+    "actions/charge-stop-via-pause-resume": EndpointDefinition(
+        "/kcm/v1/vehicles/{vin}/charge/pause-resume", mode="kcm-pause-resume"
     ),
     "charge-schedule": EndpointDefinition(
         "/kcm/v1/vehicles/{vin}/ev/settings", mode="kcm"
@@ -291,7 +291,7 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
     "X102VE": {  # ZOE phase 2
         "actions/charge-start": _DEFAULT_ENDPOINTS["actions/charge-start"],
         "actions/charge-stop": _KCM_ENDPOINTS[  # Uses KCM pause-resume
-            "actions/charge-stop"
+            "actions/charge-stop-via-pause-resume"
         ],
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
         "charge-mode": None,  # default => 400 Bad Request
@@ -307,8 +307,8 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "res-state": None,  # default => 404
     },
     "XBG1VE": {  # DACIA SPRING
-        "actions/charge-start": _KCM_ENDPOINTS["actions/charge-start"],
-        "actions/charge-stop": _KCM_ENDPOINTS["actions/charge-stop"],
+        "actions/charge-start": _KCM_ENDPOINTS["actions/charge-start-via-pause-resume"],
+        "actions/charge-stop": _KCM_ENDPOINTS["actions/charge-stop-via-pause-resume"],
         "alerts": None,  # Reason: "err.func.wired.not-found"
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
         "charge-history": None,  # Reason: "err.func.wired.not-found"

--- a/src/renault_api/renault_vehicle.py
+++ b/src/renault_api/renault_vehicle.py
@@ -570,7 +570,7 @@ class RenaultVehicle:
                 for program in current_settings["programs"]:
                     program["programActivationStatus"] = False
             json = current_settings
-        elif endpoint_definition.mode == "kcm":
+        elif endpoint_definition.mode == "kcm-pause-resume":
             json = {
                 "data": {
                     "type": "ChargePauseResume",
@@ -600,7 +600,7 @@ class RenaultVehicle:
         """Start vehicle charge."""
         endpoint_definition = await self.get_endpoint_definition("actions/charge-stop")
         json: dict[str, Any]
-        if endpoint_definition.mode == "kcm":
+        if endpoint_definition.mode == "kcm-pause-resume":
             json = {
                 "data": {
                     "type": "ChargePauseResume",

--- a/tests/__snapshots__/test_renault_vehicle.ambr
+++ b/tests/__snapshots__/test_renault_vehicle.ambr
@@ -344,8 +344,8 @@
 # ---
 # name: test_get_endpoints[tests/fixtures/kamereon/vehicles/spring.1.json]
   dict({
-    'actions/charge-start': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/charge/pause-resume', mode='kcm'),
-    'actions/charge-stop': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/charge/pause-resume', mode='kcm'),
+    'actions/charge-start': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/charge/pause-resume', mode='kcm-pause-resume'),
+    'actions/charge-stop': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/charge/pause-resume', mode='kcm-pause-resume'),
     'alerts': None,
     'battery-status': EndpointDefinition(endpoint='/kca/car-adapter/v2/cars/{vin}/battery-status', mode='default'),
     'charge-history': None,
@@ -423,7 +423,7 @@
 # name: test_get_endpoints[tests/fixtures/kamereon/vehicles/zoe_50.1.json]
   dict({
     'actions/charge-start': EndpointDefinition(endpoint='/kca/car-adapter/v1/cars/{vin}/actions/charging-start', mode='default'),
-    'actions/charge-stop': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/charge/pause-resume', mode='kcm'),
+    'actions/charge-stop': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/charge/pause-resume', mode='kcm-pause-resume'),
     'battery-status': EndpointDefinition(endpoint='/kca/car-adapter/v2/cars/{vin}/battery-status', mode='default'),
     'charge-mode': None,
     'charge-schedule': None,


### PR DESCRIPTION
This should make it clearer that it is using a "non-standard" endpoint

cc @reneboer