### PR TITLE
Add internalTemperature to KamereonVehicleHvacStatusData

### DIFF
--- a/src/renault_api/cli/renault_vehicle.py
+++ b/src/renault_api/cli/renault_vehicle.py
@@ -397,6 +397,7 @@ async def update_hvac_status(
         ("HVAC status", response.hvacStatus, None),
         ("HVAC start at", response.nextHvacStartDate, "tzdatetime"),
         ("External temperature", response.externalTemperature, "°C"),
+        ("Internal temperature", response.internalTemperature, "°C"),
     ]
 
     for key, value, unit in items:

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -943,6 +943,7 @@ class KamereonVehicleHvacStatusData(KamereonVehicleDataAttributes):
 
     lastUpdateTime: str | None
     externalTemperature: float | None
+    internalTemperature: float | None
     hvacStatus: str | None
     nextHvacStartDate: str | None
     socThreshold: float | None

--- a/tests/kamereon/__snapshots__/test_kamereon_vehicle_data.ambr
+++ b/tests/kamereon/__snapshots__/test_kamereon_vehicle_data.ambr
@@ -1,0 +1,13 @@
+# serializer version: 1
+# name: test_hvac_status[renault_5]
+  KamereonVehicleHvacStatusData(raw_data={'internalTemperature': 15.0, 'hvacStatus': 'off', 'socThreshold': 15.0, 'lastUpdateTime': '2025-03-24T18:57:22Z'}, lastUpdateTime='2025-03-24T18:57:22Z', externalTemperature=None, internalTemperature=15.0, hvacStatus='off', nextHvacStartDate=None, socThreshold=15.0)
+# ---
+# name: test_hvac_status[spring]
+  KamereonVehicleHvacStatusData(raw_data={'socThreshold': 30.0, 'hvacStatus': 'off', 'lastUpdateTime': '2020-12-03T00:00:00Z'}, lastUpdateTime='2020-12-03T00:00:00Z', externalTemperature=None, internalTemperature=None, hvacStatus='off', nextHvacStartDate=None, socThreshold=30.0)
+# ---
+# name: test_hvac_status[zoe]
+  KamereonVehicleHvacStatusData(raw_data={'externalTemperature': 8.0, 'hvacStatus': 'off'}, lastUpdateTime=None, externalTemperature=8.0, internalTemperature=None, hvacStatus='off', nextHvacStartDate=None, socThreshold=None)
+# ---
+# name: test_hvac_status[zoe_50]
+  KamereonVehicleHvacStatusData(raw_data={'socThreshold': 40, 'hvacStatus': 'on'}, lastUpdateTime=None, externalTemperature=None, internalTemperature=None, hvacStatus='on', nextHvacStartDate=None, socThreshold=40.0)
+# ---

--- a/tests/kamereon/test_kamereon_vehicle_data.py
+++ b/tests/kamereon/test_kamereon_vehicle_data.py
@@ -3,6 +3,7 @@
 from typing import cast
 
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from tests import fixtures
 
@@ -519,6 +520,23 @@ def test_hvac_settings_schedule() -> None:
         assert vehicle_data.schedules[i].id == i + 1
         for day in DAYS_OF_WEEK:
             assert vehicle_data.schedules[i].__dict__.get(day) is None
+
+
+@pytest.mark.parametrize("sub_code", ["renault_5", "spring", "zoe_50", "zoe"])
+def test_hvac_status(sub_code: str, snapshot: SnapshotAssertion) -> None:
+    """Test vehicle data with hvac settings for mode."""
+    response: models.KamereonVehicleDataResponse = fixtures.get_file_content_as_schema(
+        f"{fixtures.KAMEREON_FIXTURE_PATH}/vehicle_data/hvac-status.{sub_code}.json",
+        schemas.KamereonVehicleDataResponseSchema,
+    )
+    response.raise_for_error_code()
+
+    vehicle_data = cast(
+        models.KamereonVehicleHvacStatusData,
+        response.get_attributes(schemas.KamereonVehicleHvacStatusDataSchema),
+    )
+
+    assert vehicle_data == snapshot
 
 
 def test_no_data() -> None:


### PR DESCRIPTION
## Summary

- Add `internalTemperature: float | None` field to `KamereonVehicleHvacStatusData` dataclass
- Display it in the CLI `status` output alongside `externalTemperature`

The `hvac-status` endpoint returns `internalTemperature` for at least the Scenic E-Tech (confirmed with real vehicle data). The field is optional (`None`) so it is silently skipped for vehicles that do not return it, consistent with how `externalTemperature` is handled.

## Test plan

- [ ] Run `renault-api --log status` on a vehicle that returns `internalTemperature` and verify it shows up
- [ ] Verify that vehicles without `internalTemperature` still show status without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)