### PR TITLE
Update documentation for XCB1VE (Megane e-tech)

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -366,6 +366,7 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "notification-settings": None,  # Reason: "err.func.vcps.users-helper.get-notification-settings.error"  # noqa: E501
         "pressure": None,  # Reason: "err.func.wired.notFound"
         "res-state": None,  # Reason: "err.func.wired.notFound"
+        "soc-levels": None,  # err.func.wired.forbidden
     },
     "XFB2BI": {  # Megane IV
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],

--- a/tests/__snapshots__/test_renault_vehicle.ambr
+++ b/tests/__snapshots__/test_renault_vehicle.ambr
@@ -301,6 +301,7 @@
     'notification-settings': None,
     'pressure': None,
     'res-state': None,
+    'soc-levels': None,
   })
 # ---
 # name: test_get_endpoints[tests/fixtures/kamereon/vehicles/megane_e-tech.2.json]
@@ -326,6 +327,7 @@
     'notification-settings': None,
     'pressure': None,
     'res-state': None,
+    'soc-levels': None,
   })
 # ---
 # name: test_get_endpoints[tests/fixtures/kamereon/vehicles/renault_5.1.json]


### PR DESCRIPTION
The new soc-levels function is not supported by the Megane e-Tech. Please include this change in your next release.