### PR TITLE
Update documentation for XBG1VE (Dacia Spring)

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -316,6 +316,8 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "actions/charge-start": _KCM_ENDPOINTS["actions/charge-start-via-pause-resume"],
         "actions/charge-stop": _KCM_ENDPOINTS["actions/charge-stop-via-pause-resume"],
         "actions/horn-start": None,  # Reason: The access is forbidden,
+        "actions/hvac-start": _DEFAULT_ENDPOINTS["actions/hvac-start"],
+        "actions/hvac-stop": _KCA_ALTERNATIVE_ENDPOINTS["actions/hvac-stop"],
         "actions/lights-start": None,  # Reason: The access is forbidden,
         "alerts": None,  # Reason: "err.func.wired.not-found"
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -315,6 +315,8 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
     "XBG1VE": {  # DACIA SPRING
         "actions/charge-start": _KCM_ENDPOINTS["actions/charge-start-via-pause-resume"],
         "actions/charge-stop": _KCM_ENDPOINTS["actions/charge-stop-via-pause-resume"],
+        "actions/horn-start": None,  # Reason: The access is forbidden,
+        "actions/lights-start": None,  # Reason: The access is forbidden,
         "alerts": None,  # Reason: "err.func.wired.not-found"
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
         "charge-history": None,  # Reason: "err.func.wired.not-found"

--- a/tests/__snapshots__/test_renault_vehicle.ambr
+++ b/tests/__snapshots__/test_renault_vehicle.ambr
@@ -358,6 +358,10 @@
   dict({
     'actions/charge-start': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/charge/pause-resume', mode='kcm-pause-resume'),
     'actions/charge-stop': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/charge/pause-resume', mode='kcm-pause-resume'),
+    'actions/horn-start': None,
+    'actions/hvac-start': EndpointDefinition(endpoint='/kca/car-adapter/v1/cars/{vin}/actions/hvac-start', mode='default'),
+    'actions/hvac-stop': EndpointDefinition(endpoint='/kca/car-adapter/v1/cars/{vin}/actions/hvac-start', mode='kca-stop'),
+    'actions/lights-start': None,
     'actions/refresh-location': EndpointDefinition(endpoint='/kca/car-adapter/v1/cars/{vin}/actions/refresh-location', mode='default'),
     'alerts': None,
     'battery-status': EndpointDefinition(endpoint='/kca/car-adapter/v2/cars/{vin}/battery-status', mode='default'),


### PR DESCRIPTION
Update Dacia Spring XBG1VE endpoints for:
- disable horn-start and `lights-start` due to error: "The access is forbidden"
- add HVAC start and stop

As mentioned in #2050