### PR TITLE
Update documentation for XJA2VP (Clio V)

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -462,6 +462,11 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "hvac-status": None,
     },
     "XJA2VP": {  # CLIO V
+        "actions/charge-start": None,  # err.func.wired.forbidden
+        "actions/charge-stop": None,  # err.func.wired.invalid-body-format
+        "actions/horn-start": None,  # err.func.wired.forbidden
+        "actions/hvac-start": None,  # err.func.wired.forbidden
+        "actions/lights-start": None,  # err.func.wired.forbidden
         "alerts": None,  # err.func.wired.not-found
         "battery-status": None,  # err.func.wired.notFound
         "charge-mode": None,  # err.func.wired.forbidden

--- a/tests/__snapshots__/test_renault_vehicle.ambr
+++ b/tests/__snapshots__/test_renault_vehicle.ambr
@@ -194,6 +194,11 @@
 # ---
 # name: test_get_endpoints[tests/fixtures/kamereon/vehicles/clio_v.2.json]
   dict({
+    'actions/charge-start': None,
+    'actions/charge-stop': None,
+    'actions/horn-start': None,
+    'actions/hvac-start': None,
+    'actions/lights-start': None,
     'alerts': None,
     'battery-status': None,
     'charge-history': None,


### PR DESCRIPTION
Adds the 5 undocumented action endpoints for XJA2VP (Renault Clio V e-tech, Full Hybrid HEV). All return forbidden/not-supported — expected for a non-plug-in hybrid.

Resolves #2005