### PR TITLE
Expose Gigya login token to avoid storing the password

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,22 @@ You can install *Renault API* via pip_ from PyPI_:
    loop = asyncio.get_event_loop()
    loop.run_until_complete(main())
 
+Avoiding password storage
+-------------------------
+
+The password is only needed once: ``session.login`` exchanges it for a Gigya
+login token, which acts as a refresh token used to mint access tokens (JWTs).
+Read it from ``session.login_token`` after login, store it securely *instead of
+the password*, and restore it on the next session with ``session.set_login_token``:
+
+.. code:: python
+
+   await client.session.login('email', 'password')
+   login_token = client.session.login_token  # persist this, not the password
+
+   # later, in a new session:
+   client.session.set_login_token(login_token)  # no password required
+
 CLI Usage
 ---------
 

--- a/src/renault_api/renault_session.py
+++ b/src/renault_api/renault_session.py
@@ -65,6 +65,26 @@ class RenaultSession:
         credential = Credential(response.get_session_cookie())
         self._credentials[gigya.GIGYA_LOGIN_TOKEN] = credential
 
+    @property
+    def login_token(self) -> str | None:
+        """Return the current Gigya login token.
+
+        This token is obtained from the password on `login`, and is used to
+        mint JWTs (access tokens) without re-supplying the password. Store it
+        securely instead of the password, and restore it with `set_login_token`
+        (or by pre-populating the credential store) on the next session.
+        """
+        return self._credentials.get_value(gigya.GIGYA_LOGIN_TOKEN)
+
+    def set_login_token(self, login_token: str) -> None:
+        """Restore a Gigya login token obtained from a previous session.
+
+        This avoids storing and reusing the user password: a session restored
+        this way can mint JWTs without ever calling `login`.
+        """
+        self._credentials.clear_keys(gigya.GIGYA_KEYS)
+        self._credentials[gigya.GIGYA_LOGIN_TOKEN] = Credential(login_token)
+
     async def _get_credential(self, key: str) -> str:
         """Get specified credential, or raise RenaultException."""
         if key not in self._credentials:

--- a/tests/test_renault_session.py
+++ b/tests/test_renault_session.py
@@ -181,6 +181,35 @@ async def test_login(session: RenaultSession, mocked_responses: aioresponses) ->
 
 
 @pytest.mark.asyncio
+async def test_login_token_property(
+    session: RenaultSession, mocked_responses: aioresponses
+) -> None:
+    """Test that the login token is exposed after login."""
+    assert session.login_token is None
+
+    fixtures.inject_gigya_all(mocked_responses)
+    await session.login(TEST_USERNAME, TEST_PASSWORD)
+
+    assert session.login_token == TEST_LOGIN_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_set_login_token(
+    session: RenaultSession, mocked_responses: aioresponses
+) -> None:
+    """Test restoring a login token instead of using the password."""
+    session.set_login_token(TEST_LOGIN_TOKEN)
+
+    assert session.login_token == TEST_LOGIN_TOKEN
+    assert await session._get_login_token() == TEST_LOGIN_TOKEN
+
+    # A restored token can mint a JWT without ever calling login.
+    fixtures.inject_gigya_jwt(mocked_responses)
+    assert await session._get_jwt()
+    assert len(mocked_responses.requests) == 1
+
+
+@pytest.mark.asyncio
 async def test_expired_login_token(
     websession: aiohttp.ClientSession, mocked_responses: aioresponses
 ) -> None:


### PR DESCRIPTION
Add `RenaultSession.login_token` and `set_login_token()` so consumers can persist the Gigya login token (the refresh-token equivalent) instead of the user password, and restore a session without re-authenticating.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>