### PR TITLE
Update documentation for XCB1VE (Megane e-tech)

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -388,7 +388,7 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "notification-settings": None,  # Reason: "err.func.vcps.users-helper.get-notification-settings.error"  # noqa: E501
         "pressure": None,  # Reason: "err.func.wired.notFound"
         "res-state": None,  # Reason: "err.func.wired.notFound"
-        "soc-levels": None,  # Reason: "err.func.wired.forbidden"
+        "soc-levels": _DEFAULT_ENDPOINTS["soc-levels"],
     },
     "XFB2BI": {  # Megane IV
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],

--- a/tests/__snapshots__/test_renault_vehicle.ambr
+++ b/tests/__snapshots__/test_renault_vehicle.ambr
@@ -319,7 +319,7 @@
     'notification-settings': None,
     'pressure': None,
     'res-state': None,
-    'soc-levels': None,
+    'soc-levels': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/ev/soc-levels', mode='default'),
   })
 # ---
 # name: test_get_endpoints[tests/fixtures/kamereon/vehicles/megane_e-tech.2.json]
@@ -345,7 +345,7 @@
     'notification-settings': None,
     'pressure': None,
     'res-state': None,
-    'soc-levels': None,
+    'soc-levels': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/ev/soc-levels', mode='default'),
   })
 # ---
 # name: test_get_endpoints[tests/fixtures/kamereon/vehicles/renault_5.1.json]


### PR DESCRIPTION
## Summary

Restores the `soc-levels` endpoint for model `XCB1VE` (Renault Megane E-Tech), which was previously set to `None` with the comment `err.func.wired.forbidden`.

## Change

```python
# Before
"soc-levels": None,  # Reason: "err.func.wired.forbidden"

# After
"soc-levels": _DEFAULT_ENDPOINTS["soc-levels"],
```

## Background

The `soc-levels` endpoint (`/kcm/v1/vehicles/{vin}/ev/soc-levels`) was disabled for all Megane E-Tech owners based on a `403 Forbidden` response

## Tested

- **Model code:** `XCB1VE` (Renault Megane E-Tech)
- **VIN prefix:** `VF1RCB`
- **Locale:** `nl_NL`
- **renault-api version:** 0.5.10

With this fix applied, the endpoint responds correctly and returns `socMin` and `socTarget` without any 403 error. Both entities are restored and functional in Home Assistant.