### PR TITLE
Bump version to 0.5.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "renault-api"
-version = "0.5.10"
+version = "0.5.11"
 description = "Renault API"
 authors = ["epenet"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps the version from `0.5.10` to `0.5.11`.

## Changes included in this release

- Fix XCB1VE (Megane E-Tech): restore `soc-levels` endpoint incorrectly set to `None` (#2118)

## Related

- #2118