### PR TITLE
Add documentation for Dacia Sandero III (XJF2BI)

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -390,32 +390,6 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "res-state": None,  # Reason: "err.func.wired.notFound"
         "soc-levels": _DEFAULT_ENDPOINTS["soc-levels"],
     },
-    "XDD1VE": {  # Renault Master E-Tech
-        "actions/charge-set-mode": _DEFAULT_ENDPOINTS["actions/charge-set-mode"],
-        "actions/charge-set-schedule": None,  # err.func.wired.forbidden
-        "actions/charge-start": _KCM_ENDPOINTS["actions/charge-start-via-settings"],
-        "actions/charge-stop": None,  # err.func.wired.forbidden
-        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
-        "actions/hvac-start": _DEFAULT_ENDPOINTS["actions/hvac-start"],
-        "actions/hvac-stop": _DEFAULT_ENDPOINTS["actions/hvac-stop"],
-        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
-        "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
-        "charge-history": None,  # err.func.wired.not-found
-        "charge-mode": None,  # err.func.wired.forbidden
-        "charge-schedule": _KCM_ENDPOINTS["charge-schedule-via-settings"],
-        "charging-settings": None,  # err.func.wired.forbidden
-        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],
-        "hvac-history": None,  # err.func.wired.not-found
-        "hvac-sessions": None,  # err.func.wired.not-found
-        "hvac-settings": _DEFAULT_ENDPOINTS["hvac-settings"],
-        "hvac-status": _DEFAULT_ENDPOINTS["hvac-status"],
-        "location": _DEFAULT_ENDPOINTS["location"],
-        "lock-status": None,  # 404 There is no data for this vin and uid
-        "notification-settings": None,  # 400001 The vehicle does not have a GDC gateway
-        "pressure": None,  # 404 There is no data for this vin and uid
-        "res-state": None,  # 404 There is no data for this vin and uid
-        "soc-levels": _DEFAULT_ENDPOINTS["soc-levels"],
-    },
     "XFB2BI": {  # Megane IV
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
         "charge-history": None,  # Reason: "err.func.wired.not-found"
@@ -453,6 +427,24 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "pressure": None,  # Reason: "err.func.wired.notFound"
         "res-state": None,  # Reason: "err.func.wired.notFound"
     },
+    "XHN1SU": {  # AUSTRAL
+        "actions/charge-start": None,  # Reason: "err.func.wired.forbidden"
+        "actions/charge-stop": None,  # Reason: "err.func.wired.not-found"
+        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
+        "actions/hvac-start": None,  # Reason: "err.func.wired.methodNotAllowed"
+        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
+        "battery-status": None,  # Reason: "err.func.wired.notFound"
+        "charge-history": None,  # Reason: "err.func.wired.not-found"
+        "charge-mode": None,  # Reason: "err.func.wired.forbidden"
+        "charging-settings": None,  # Reason: "err.func.wired.forbidden"
+        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],  # confirmed
+        "hvac-status": None,
+        "location": _DEFAULT_ENDPOINTS["location"],
+        "lock-status": None,
+        "pressure": None,  # Reason: 404
+        "res-state": None,
+        "soc-levels": None,  # Reason: "err.func.wired.forbidden"
+    },
     "XHN1ML": {  # Renault Espace VI (OpenRLink)
         "actions/hvac-start": None,  # err.func.wired.forbidden
         "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
@@ -474,24 +466,6 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "pressure": None,  # err.func.wired.notFound
         "res-state": None,  # err.func.wired.notFound
         "soc-levels": None,  # err.func.wired.notFound
-    },
-    "XHN1SU": {  # AUSTRAL
-        "actions/charge-start": None,  # Reason: "err.func.wired.forbidden"
-        "actions/charge-stop": None,  # Reason: "err.func.wired.not-found"
-        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
-        "actions/hvac-start": None,  # Reason: "err.func.wired.methodNotAllowed"
-        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
-        "battery-status": None,  # Reason: "err.func.wired.notFound"
-        "charge-history": None,  # Reason: "err.func.wired.not-found"
-        "charge-mode": None,  # Reason: "err.func.wired.forbidden"
-        "charging-settings": None,  # Reason: "err.func.wired.forbidden"
-        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],  # confirmed
-        "hvac-status": None,
-        "location": _DEFAULT_ENDPOINTS["location"],
-        "lock-status": None,
-        "pressure": None,  # Reason: 404
-        "res-state": None,
-        "soc-levels": None,  # Reason: "err.func.wired.forbidden"
     },
     "XJA1VP": {  # CLIO V
         "actions/charge-start": None,  # err.func.wired.forbidden
@@ -553,6 +527,48 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "res-state": None,  # err.func.wired.notFound
         "soc-levels": None,  # err.func.wired.forbidden
     },
+    "XDD1VE": {  # Renault Master E-Tech
+        "actions/charge-set-mode": _DEFAULT_ENDPOINTS["actions/charge-set-mode"],
+        "actions/charge-set-schedule": None,  # err.func.wired.forbidden
+        "actions/charge-start": _KCM_ENDPOINTS["actions/charge-start-via-settings"],
+        "actions/charge-stop": None,  # err.func.wired.forbidden
+        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
+        "actions/hvac-start": _DEFAULT_ENDPOINTS["actions/hvac-start"],
+        "actions/hvac-stop": _DEFAULT_ENDPOINTS["actions/hvac-stop"],
+        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
+        "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
+        "charge-history": None,  # err.func.wired.not-found
+        "charge-mode": None,  # err.func.wired.forbidden
+        "charge-schedule": _KCM_ENDPOINTS["charge-schedule-via-settings"],
+        "charging-settings": None,  # err.func.wired.forbidden
+        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],
+        "hvac-history": None,  # err.func.wired.not-found
+        "hvac-sessions": None,  # err.func.wired.not-found
+        "hvac-settings": _DEFAULT_ENDPOINTS["hvac-settings"],
+        "hvac-status": _DEFAULT_ENDPOINTS["hvac-status"],
+        "location": _DEFAULT_ENDPOINTS["location"],
+        "lock-status": None,  # 404 There is no data for this vin and uid
+        "notification-settings": None,  # 400001 The vehicle does not have a GDC gateway
+        "pressure": None,  # 404 There is no data for this vin and uid
+        "res-state": None,  # 404 There is no data for this vin and uid
+        "soc-levels": _DEFAULT_ENDPOINTS["soc-levels"],
+    },
+    "XJB2CP": {  # Renault Symbioz 2025
+        "actions/charge-start": None,  # err.func.wired.forbidden
+        "actions/charge-stop": None,  # err.func.wired.invalid-body-format
+        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
+        "actions/hvac-start": None,  # err.func.wired.forbidden
+        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
+        "battery-status": None,  # err.func.wired.notFound
+        "charge-mode": None,  # err.func.wired.forbidden
+        "charging-settings": None,  # err.func.wired.forbidden
+        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],  # confirmed
+        "hvac-status": None,  # err.func.wired.notFound
+        "location": _DEFAULT_ENDPOINTS["location"],
+        "lock-status": None,  # err.func.wired.notFound
+        "res-state": None,  # err.func.wired.notFound
+        "pressure": None,  # err.func.wired.notFound
+    },
     "XJB1SU": {  # CAPTUR II
         "actions/charge-start": None,  # Reason: "err.func.wired.not-found"
         "actions/charge-stop": None,  # Reason: "err.func.wired.not-found"
@@ -575,22 +591,6 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "pressure": None,  # Reason: "err.func.wired.notFound"
         "res-state": None,  # Reason: "err.func.wired.notFound"
         "soc-levels": None,  # Reason: "err.func.wired.forbidden"
-    },
-    "XJB2CP": {  # Renault Symbioz 2025
-        "actions/charge-start": None,  # err.func.wired.forbidden
-        "actions/charge-stop": None,  # err.func.wired.invalid-body-format
-        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
-        "actions/hvac-start": None,  # err.func.wired.forbidden
-        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
-        "battery-status": None,  # err.func.wired.notFound
-        "charge-mode": None,  # err.func.wired.forbidden
-        "charging-settings": None,  # err.func.wired.forbidden
-        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],  # confirmed
-        "hvac-status": None,  # err.func.wired.notFound
-        "location": _DEFAULT_ENDPOINTS["location"],
-        "lock-status": None,  # err.func.wired.notFound
-        "res-state": None,  # err.func.wired.notFound
-        "pressure": None,  # err.func.wired.notFound
     },
     "XJF2BI": {  # DACIA SANDERO III (ECO-G, petrol+LPG; engineEnergyType OTHER)
         "actions/charge-set-mode": None,  # no EV

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -527,6 +527,36 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "res-state": None,  # err.func.wired.notFound
         "soc-levels": None,  # err.func.wired.forbidden
     },
+    "XJF2BI": {  # DACIA SANDERO III (ECO-G, petrol+LPG; engineEnergyType OTHER)
+        "actions/charge-set-mode": None,  # no EV
+        "actions/charge-set-schedule": None,  # no EV
+        "actions/charge-start": None,  # no EV
+        "actions/charge-stop": None,  # no EV
+        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
+        "actions/hvac-set-schedule": None,  # no remote HVAC
+        "actions/hvac-start": None,  # err.func.wired.forbidden (unauthorized)
+        "actions/hvac-stop": None,  # err.func.wired.forbidden (unauthorized)
+        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
+        "actions/refresh-location": _DEFAULT_ENDPOINTS["actions/refresh-location"],
+        "alerts": None,  # err.func.wired.not-found
+        "battery-status": None,  # err.func.wired.notFound
+        "charge-history": None,  # err.func.wired.not-found
+        "charge-mode": None,  # err.func.wired.forbidden
+        "charge-schedule": None,  # err.func.wired.forbidden
+        "charges": None,  # err.func.wired.missingRequestParam (no EV)
+        "charging-settings": None,  # err.func.wired.forbidden
+        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],  # fuelQuantity (petrol), totalMileage
+        "hvac-history": None,  # err.func.wired.not-found
+        "hvac-sessions": None,  # err.func.wired.not-found
+        "hvac-settings": None,  # err.func.wired.forbidden
+        "hvac-status": None,  # err.func.wired.notFound
+        "location": _DEFAULT_ENDPOINTS["location"],
+        "lock-status": None,  # err.func.wired.notFound
+        "notification-settings": None,  # 400001 The vehicle does not have a GDC gateway
+        "pressure": None,  # err.func.wired.notFound
+        "res-state": None,  # err.func.wired.notFound
+        "soc-levels": None,  # err.func.wired.forbidden
+    },
     "XDD1VE": {  # Renault Master E-Tech
         "actions/charge-set-mode": _DEFAULT_ENDPOINTS["actions/charge-set-mode"],
         "actions/charge-set-schedule": None,  # err.func.wired.forbidden

--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -390,6 +390,32 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "res-state": None,  # Reason: "err.func.wired.notFound"
         "soc-levels": _DEFAULT_ENDPOINTS["soc-levels"],
     },
+    "XDD1VE": {  # Renault Master E-Tech
+        "actions/charge-set-mode": _DEFAULT_ENDPOINTS["actions/charge-set-mode"],
+        "actions/charge-set-schedule": None,  # err.func.wired.forbidden
+        "actions/charge-start": _KCM_ENDPOINTS["actions/charge-start-via-settings"],
+        "actions/charge-stop": None,  # err.func.wired.forbidden
+        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
+        "actions/hvac-start": _DEFAULT_ENDPOINTS["actions/hvac-start"],
+        "actions/hvac-stop": _DEFAULT_ENDPOINTS["actions/hvac-stop"],
+        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
+        "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
+        "charge-history": None,  # err.func.wired.not-found
+        "charge-mode": None,  # err.func.wired.forbidden
+        "charge-schedule": _KCM_ENDPOINTS["charge-schedule-via-settings"],
+        "charging-settings": None,  # err.func.wired.forbidden
+        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],
+        "hvac-history": None,  # err.func.wired.not-found
+        "hvac-sessions": None,  # err.func.wired.not-found
+        "hvac-settings": _DEFAULT_ENDPOINTS["hvac-settings"],
+        "hvac-status": _DEFAULT_ENDPOINTS["hvac-status"],
+        "location": _DEFAULT_ENDPOINTS["location"],
+        "lock-status": None,  # 404 There is no data for this vin and uid
+        "notification-settings": None,  # 400001 The vehicle does not have a GDC gateway
+        "pressure": None,  # 404 There is no data for this vin and uid
+        "res-state": None,  # 404 There is no data for this vin and uid
+        "soc-levels": _DEFAULT_ENDPOINTS["soc-levels"],
+    },
     "XFB2BI": {  # Megane IV
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
         "charge-history": None,  # Reason: "err.func.wired.not-found"
@@ -427,24 +453,6 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "pressure": None,  # Reason: "err.func.wired.notFound"
         "res-state": None,  # Reason: "err.func.wired.notFound"
     },
-    "XHN1SU": {  # AUSTRAL
-        "actions/charge-start": None,  # Reason: "err.func.wired.forbidden"
-        "actions/charge-stop": None,  # Reason: "err.func.wired.not-found"
-        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
-        "actions/hvac-start": None,  # Reason: "err.func.wired.methodNotAllowed"
-        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
-        "battery-status": None,  # Reason: "err.func.wired.notFound"
-        "charge-history": None,  # Reason: "err.func.wired.not-found"
-        "charge-mode": None,  # Reason: "err.func.wired.forbidden"
-        "charging-settings": None,  # Reason: "err.func.wired.forbidden"
-        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],  # confirmed
-        "hvac-status": None,
-        "location": _DEFAULT_ENDPOINTS["location"],
-        "lock-status": None,
-        "pressure": None,  # Reason: 404
-        "res-state": None,
-        "soc-levels": None,  # Reason: "err.func.wired.forbidden"
-    },
     "XHN1ML": {  # Renault Espace VI (OpenRLink)
         "actions/hvac-start": None,  # err.func.wired.forbidden
         "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
@@ -466,6 +474,24 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "pressure": None,  # err.func.wired.notFound
         "res-state": None,  # err.func.wired.notFound
         "soc-levels": None,  # err.func.wired.notFound
+    },
+    "XHN1SU": {  # AUSTRAL
+        "actions/charge-start": None,  # Reason: "err.func.wired.forbidden"
+        "actions/charge-stop": None,  # Reason: "err.func.wired.not-found"
+        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
+        "actions/hvac-start": None,  # Reason: "err.func.wired.methodNotAllowed"
+        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
+        "battery-status": None,  # Reason: "err.func.wired.notFound"
+        "charge-history": None,  # Reason: "err.func.wired.not-found"
+        "charge-mode": None,  # Reason: "err.func.wired.forbidden"
+        "charging-settings": None,  # Reason: "err.func.wired.forbidden"
+        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],  # confirmed
+        "hvac-status": None,
+        "location": _DEFAULT_ENDPOINTS["location"],
+        "lock-status": None,
+        "pressure": None,  # Reason: 404
+        "res-state": None,
+        "soc-levels": None,  # Reason: "err.func.wired.forbidden"
     },
     "XJA1VP": {  # CLIO V
         "actions/charge-start": None,  # err.func.wired.forbidden
@@ -527,6 +553,45 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "res-state": None,  # err.func.wired.notFound
         "soc-levels": None,  # err.func.wired.forbidden
     },
+    "XJB1SU": {  # CAPTUR II
+        "actions/charge-start": None,  # Reason: "err.func.wired.not-found"
+        "actions/charge-stop": None,  # Reason: "err.func.wired.not-found"
+        "actions/horn-start": None,  # Reason: "err.func.wired.not-found"
+        "actions/hvac-start": _DEFAULT_ENDPOINTS["actions/hvac-start"],
+        "actions/lights-start": None,  # Reason: "err.func.wired.not-found"
+        "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
+        "charge-history": None,  # Reason: "err.func.wired.not-found"
+        "charge-mode": None,  # Reason: "err.func.vcps.ev.charge-mode.error"
+        "charge-schedule": None,  # Reason: "err.func.vcps.ev.charge-schedule.error"
+        "charging-settings": _DEFAULT_ENDPOINTS["charging-settings"],
+        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],
+        "hvac-history": None,  # Reason: "err.func.wired.not-found"
+        "hvac-sessions": None,  # Reason: "err.func.wired.not-found"
+        "hvac-settings": _DEFAULT_ENDPOINTS["hvac-settings"],
+        "hvac-status": _DEFAULT_ENDPOINTS["hvac-status"],
+        "location": _DEFAULT_ENDPOINTS["location"],
+        "lock-status": None,  # Reason: "err.func.wired.notFound"
+        "notification-settings": None,  # Reason: "err.func.vcps.users-helper.get-notification-settings.error"  # noqa: E501
+        "pressure": None,  # Reason: "err.func.wired.notFound"
+        "res-state": None,  # Reason: "err.func.wired.notFound"
+        "soc-levels": None,  # Reason: "err.func.wired.forbidden"
+    },
+    "XJB2CP": {  # Renault Symbioz 2025
+        "actions/charge-start": None,  # err.func.wired.forbidden
+        "actions/charge-stop": None,  # err.func.wired.invalid-body-format
+        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
+        "actions/hvac-start": None,  # err.func.wired.forbidden
+        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
+        "battery-status": None,  # err.func.wired.notFound
+        "charge-mode": None,  # err.func.wired.forbidden
+        "charging-settings": None,  # err.func.wired.forbidden
+        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],  # confirmed
+        "hvac-status": None,  # err.func.wired.notFound
+        "location": _DEFAULT_ENDPOINTS["location"],
+        "lock-status": None,  # err.func.wired.notFound
+        "res-state": None,  # err.func.wired.notFound
+        "pressure": None,  # err.func.wired.notFound
+    },
     "XJF2BI": {  # DACIA SANDERO III (ECO-G, petrol+LPG; engineEnergyType OTHER)
         "actions/charge-set-mode": None,  # no EV
         "actions/charge-set-schedule": None,  # no EV
@@ -556,71 +621,6 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "pressure": None,  # err.func.wired.notFound
         "res-state": None,  # err.func.wired.notFound
         "soc-levels": None,  # err.func.wired.forbidden
-    },
-    "XDD1VE": {  # Renault Master E-Tech
-        "actions/charge-set-mode": _DEFAULT_ENDPOINTS["actions/charge-set-mode"],
-        "actions/charge-set-schedule": None,  # err.func.wired.forbidden
-        "actions/charge-start": _KCM_ENDPOINTS["actions/charge-start-via-settings"],
-        "actions/charge-stop": None,  # err.func.wired.forbidden
-        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
-        "actions/hvac-start": _DEFAULT_ENDPOINTS["actions/hvac-start"],
-        "actions/hvac-stop": _DEFAULT_ENDPOINTS["actions/hvac-stop"],
-        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
-        "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
-        "charge-history": None,  # err.func.wired.not-found
-        "charge-mode": None,  # err.func.wired.forbidden
-        "charge-schedule": _KCM_ENDPOINTS["charge-schedule-via-settings"],
-        "charging-settings": None,  # err.func.wired.forbidden
-        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],
-        "hvac-history": None,  # err.func.wired.not-found
-        "hvac-sessions": None,  # err.func.wired.not-found
-        "hvac-settings": _DEFAULT_ENDPOINTS["hvac-settings"],
-        "hvac-status": _DEFAULT_ENDPOINTS["hvac-status"],
-        "location": _DEFAULT_ENDPOINTS["location"],
-        "lock-status": None,  # 404 There is no data for this vin and uid
-        "notification-settings": None,  # 400001 The vehicle does not have a GDC gateway
-        "pressure": None,  # 404 There is no data for this vin and uid
-        "res-state": None,  # 404 There is no data for this vin and uid
-        "soc-levels": _DEFAULT_ENDPOINTS["soc-levels"],
-    },
-    "XJB2CP": {  # Renault Symbioz 2025
-        "actions/charge-start": None,  # err.func.wired.forbidden
-        "actions/charge-stop": None,  # err.func.wired.invalid-body-format
-        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
-        "actions/hvac-start": None,  # err.func.wired.forbidden
-        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
-        "battery-status": None,  # err.func.wired.notFound
-        "charge-mode": None,  # err.func.wired.forbidden
-        "charging-settings": None,  # err.func.wired.forbidden
-        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],  # confirmed
-        "hvac-status": None,  # err.func.wired.notFound
-        "location": _DEFAULT_ENDPOINTS["location"],
-        "lock-status": None,  # err.func.wired.notFound
-        "res-state": None,  # err.func.wired.notFound
-        "pressure": None,  # err.func.wired.notFound
-    },
-    "XJB1SU": {  # CAPTUR II
-        "actions/charge-start": None,  # Reason: "err.func.wired.not-found"
-        "actions/charge-stop": None,  # Reason: "err.func.wired.not-found"
-        "actions/horn-start": None,  # Reason: "err.func.wired.not-found"
-        "actions/hvac-start": _DEFAULT_ENDPOINTS["actions/hvac-start"],
-        "actions/lights-start": None,  # Reason: "err.func.wired.not-found"
-        "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
-        "charge-history": None,  # Reason: "err.func.wired.not-found"
-        "charge-mode": None,  # Reason: "err.func.vcps.ev.charge-mode.error"
-        "charge-schedule": None,  # Reason: "err.func.vcps.ev.charge-schedule.error"
-        "charging-settings": _DEFAULT_ENDPOINTS["charging-settings"],
-        "cockpit": _DEFAULT_ENDPOINTS["cockpit"],
-        "hvac-history": None,  # Reason: "err.func.wired.not-found"
-        "hvac-sessions": None,  # Reason: "err.func.wired.not-found"
-        "hvac-settings": _DEFAULT_ENDPOINTS["hvac-settings"],
-        "hvac-status": _DEFAULT_ENDPOINTS["hvac-status"],
-        "location": _DEFAULT_ENDPOINTS["location"],
-        "lock-status": None,  # Reason: "err.func.wired.notFound"
-        "notification-settings": None,  # Reason: "err.func.vcps.users-helper.get-notification-settings.error"  # noqa: E501
-        "pressure": None,  # Reason: "err.func.wired.notFound"
-        "res-state": None,  # Reason: "err.func.wired.notFound"
-        "soc-levels": None,  # Reason: "err.func.wired.forbidden"
     },
     "XJL2TR": {  # Arkana E-tech full hybrid
         "cockpit": _DEFAULT_ENDPOINTS["cockpit"],  # confirmed


### PR DESCRIPTION
## Summary

Documents `_VEHICLE_ENDPOINTS` for the **Dacia Sandero III** (model code `XJF2BI`, ECO-G bi-fuel petrol+LPG, `engineEnergyType: OTHER`), as requested in #1747.

Without this entry the model falls back to `_DEFAULT_ENDPOINTS`, which makes Home Assistant create entities the car does not have (e.g. an HVAC button that returns *unauthorized*) and emits the "model is not documented" warning.

## How it was tested

`renault-api` 0.5.12 CLI (`http get`) + Home Assistant 2026.6.2 diagnostics.

| Endpoint | Result |
|---|---|
| `cockpit` | ✅ `fuelQuantity` (petrol), `totalMileage` |
| `location` | ✅ |
| `actions/horn-start`, `actions/lights-start` | ✅ available in the MyDacia app (horn / 3× flash) |
| `actions/hvac-start` / `-stop` | ❌ unauthorized |
| `battery-status`, `hvac-status`, `lock-status`, `res-state`, `pressure` | ❌ `err.func.wired.notFound` |
| `charge-history`, `hvac-history`, `hvac-sessions`, `alerts` | ❌ `err.func.wired.not-found` |
| `charge-mode`, `charge-schedule`, `charging-settings`, `hvac-settings` | ❌ `err.func.wired.forbidden` |
| `notification-settings` | ❌ `400001 The vehicle does not have a GDC gateway` |

The LPG (second) fuel level is **not** exposed by the cockpit endpoint (tested with an empty LPG tank), so only the petrol level is available.

Action POSTs other than the confirmed horn/lights were not fired to avoid triggering the car. `actions/refresh-location` is mapped to the default since `location` reads work.

Refs #1747

🤖 Generated with [Claude Code](https://claude.com/claude-code)
