### PR TITLE
Fix X102VE charge start and stop actions

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -166,6 +166,9 @@ _KCM_ENDPOINTS: dict[str, EndpointDefinition] = {
     "actions/charge-stop-via-pause-resume": EndpointDefinition(
         "/kcm/v1/vehicles/{vin}/charge/pause-resume", mode="kcm-pause-resume"
     ),
+    "actions/charge-stop-via-delayed-start": EndpointDefinition(
+        "/kcm/v1/vehicles/{vin}/charge/start", mode="kcm-delayed-start"
+    ),
     "charge-schedule-via-settings": EndpointDefinition(
         "/kcm/v1/vehicles/{vin}/ev/settings", mode="kcm-settings"
     ),
@@ -316,10 +319,8 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "soc-levels": None,  # not supported
     },
     "X102VE": {  # ZOE phase 2
-        "actions/charge-start": _DEFAULT_ENDPOINTS["actions/charge-start"],
-        "actions/charge-stop": _KCM_ENDPOINTS[  # Uses KCM pause-resume
-            "actions/charge-stop-via-pause-resume"
-        ],
+        "actions/charge-start": _KCM_ENDPOINTS["actions/charge-start"],
+        "actions/charge-stop": _KCM_ENDPOINTS["actions/charge-stop-via-delayed-start"],
         "actions/horn-start": None,  # Reason: The access is forbidden,
         "actions/hvac-start": _DEFAULT_ENDPOINTS["actions/hvac-start"],
         "actions/lights-start": None,  # Reason: The access is forbidden,

--- a/src/renault_api/renault_vehicle.py
+++ b/src/renault_api/renault_vehicle.py
@@ -1,6 +1,7 @@
 """Client for Renault API."""
 
 from datetime import datetime
+from datetime import timedelta
 from datetime import timezone
 from typing import Any
 from typing import cast
@@ -18,6 +19,8 @@ from .renault_session import RenaultSession
 PERIOD_DAY_FORMAT = "%Y%m%d"
 PERIOD_MONTH_FORMAT = "%Y%m"
 PERIOD_TZ_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+KCM_DELAYED_START_FORMAT = "%Y-%m-%dT%H:%M:00.000Z"
+X102VE_CHARGE_STOP_DELAY = timedelta(hours=24)
 PERIOD_FORMATS = {"day": PERIOD_DAY_FORMAT, "month": PERIOD_MONTH_FORMAT}
 
 
@@ -613,7 +616,7 @@ class RenaultVehicle:
         )
 
     async def set_charge_stop(self) -> models.KamereonVehicleChargingStartActionData:
-        """Start vehicle charge."""
+        """Stop vehicle charge."""
         endpoint_definition = await self.get_endpoint_definition("actions/charge-stop")
         json: dict[str, Any]
         if endpoint_definition.mode == "kcm-pause-resume":
@@ -622,6 +625,20 @@ class RenaultVehicle:
                     "type": "ChargePauseResume",
                     "attributes": {
                         "action": "pause",
+                    },
+                }
+            }
+        elif endpoint_definition.mode == "kcm-delayed-start":
+            # X102VE ignores pause, but postponing its next start stops charging.
+            start_date_time = (
+                datetime.now(timezone.utc) + X102VE_CHARGE_STOP_DELAY
+            ).strftime(KCM_DELAYED_START_FORMAT)
+            json = {
+                "data": {
+                    "type": "ChargingStart",
+                    "attributes": {
+                        "action": "start",
+                        "startDateTime": start_date_time,
                     },
                 }
             }

--- a/tests/__snapshots__/test_renault_vehicle.ambr
+++ b/tests/__snapshots__/test_renault_vehicle.ambr
@@ -537,8 +537,8 @@
 # ---
 # name: test_get_endpoints[tests/fixtures/kamereon/vehicles/zoe_50.1.json]
   dict({
-    'actions/charge-start': EndpointDefinition(endpoint='/kca/car-adapter/v1/cars/{vin}/actions/charging-start', mode='default'),
-    'actions/charge-stop': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/charge/pause-resume', mode='kcm-pause-resume'),
+    'actions/charge-start': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/charge/start', mode='kcm'),
+    'actions/charge-stop': EndpointDefinition(endpoint='/kcm/v1/vehicles/{vin}/charge/start', mode='kcm-delayed-start'),
     'actions/horn-start': None,
     'actions/hvac-start': EndpointDefinition(endpoint='/kca/car-adapter/v1/cars/{vin}/actions/hvac-start', mode='default'),
     'actions/lights-start': None,
@@ -819,6 +819,16 @@
     }),
   })
 # ---
+# name: test_set_charge_start[zoe_50_1-now]
+  dict({
+    'data': dict({
+      'attributes': dict({
+        'action': 'start',
+      }),
+      'type': 'ChargingStart',
+    }),
+  })
+# ---
 # name: test_set_charge_start_r5
   dict({
     'chargeDuration': 9000,
@@ -844,6 +854,17 @@
         'programType': 'CHARGE_AND_PRECONDITIONING',
       }),
     ]),
+  })
+# ---
+# name: test_set_charge_stop_zoe_50
+  dict({
+    'data': dict({
+      'attributes': dict({
+        'action': 'start',
+        'startDateTime': '2026-03-07T23:45:00.000Z',
+      }),
+      'type': 'ChargingStart',
+    }),
   })
 # ---
 # name: test_set_hvac_schedules

--- a/tests/test_renault_vehicle.py
+++ b/tests/test_renault_vehicle.py
@@ -490,11 +490,18 @@ async def test_set_charge_schedules_update(
             f"{KCA_ADAPTER_PATH_V1}/actions/charging-start?{DEFAULT_QUERY_STRING}",
             "vehicle_action/charging-start.start.json",
         ),
+        (
+            "zoe_50.1.json",
+            {},
+            f"{KCM_ADAPTER_PATH}/charge/start?{DEFAULT_QUERY_STRING}",
+            "vehicle_kcm_action/charging-start.now.json",
+        ),
     ],
     ids=[
         "megane_e_tech_2-now",
         "megane_e_tech_2-delayed",
         "zoe_40_1-now",
+        "zoe_50_1-now",
     ],
 )
 @pytest.mark.asyncio
@@ -512,6 +519,33 @@ async def test_set_charge_start(
     url = fixtures.inject_action(mocked_responses, action_url, action_result)
 
     assert await vehicle.set_charge_start(**arguments)
+    request = mocked_responses.requests[("POST", URL(url))][0]
+    assert request.kwargs["json"] == snapshot
+
+
+@pytest.mark.asyncio
+async def test_set_charge_stop_zoe_50(
+    vehicle: RenaultVehicle,
+    mocked_responses: aiointercept,
+    monkeypatch: pytest.MonkeyPatch,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test X102VE charge stop via a delayed KCM start."""
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz: timezone | None = None) -> datetime:
+            return datetime(2026, 3, 6, 23, 45, tzinfo=tz)
+
+    monkeypatch.setattr("renault_api.renault_vehicle.datetime", FixedDateTime)
+    fixtures.inject_get_vehicle_details(mocked_responses, "zoe_50.1.json")
+    url = fixtures.inject_action(
+        mocked_responses,
+        f"{KCM_ADAPTER_PATH}/charge/start?{DEFAULT_QUERY_STRING}",
+        "vehicle_kcm_action/charging-start.delayed.json",
+    )
+
+    assert await vehicle.set_charge_stop()
     request = mocked_responses.requests[("POST", URL(url))][0]
     assert request.kwargs["json"] == snapshot
 


### PR DESCRIPTION
## Summary

- use the current KCM `/charge/start` action for immediate charging on `X102VE`
- replace the accepted-but-ineffective KCM pause command with a delayed KCM start 24 hours ahead for stopping charge
- cover the X102VE endpoint mapping and both command payloads with tests

## Physical vehicle validation

Tested on a plugged-in Renault Zoe Phase 2 (`X102VE`):

- start: `energy_flap_opened` -> waiting states -> `charge_in_progress`
- stop: `charge_in_progress` -> `energy_flap_opened`, with charging ending immediately

The existing `/charge/pause-resume` `pause` response was accepted by the API but
did not stop this vehicle. The delayed-start payload uses the command shape
observed in the current MyRenault app and preserves the existing public
`set_charge_stop()` API.

Related to #2133 and the current-app command capture in #1946.

The downstream Home Assistant Core PR is
[home-assistant/core#176765](https://github.com/home-assistant/core/pull/176765).
Per the Core code owner's request, it is closed until this PR is merged and the
next `renault-api` release is published on PyPI.

## Tests

Fresh validation on `b8db30b`, rebased onto current `main`:

- `pytest -q`: 365 passed, 30 skipped, 174 snapshots passed
- `ruff check .`
- `ruff format --check .`
- `mypy src`

The GitHub Actions workflow for this first-time contribution requires a
repository maintainer to approve the run.
