### PR TITLE
Update documentation for XCB1SE (Scenic E-Tech)

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -386,15 +386,23 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "soc-levels": None,  # Reason: "err.func.wired.forbidden"
     },
     "XCB1SE": {  # SCENIC E-TECH
+        "actions/charge-start": _KCM_ENDPOINTS["actions/charge-start-via-settings"],
+        "actions/charge-stop": None,  # Reason: "err.func.wired.forbidden" (kcm pause-resume) / "err.func.wired.invalid-body-format" (default)  # noqa: E501
+        "actions/horn-start": _DEFAULT_ENDPOINTS["actions/horn-start"],
+        "actions/hvac-start": _DEFAULT_ENDPOINTS["actions/hvac-start"],
+        "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
         "charge-mode": None,
         "charge-schedule": _KCM_ENDPOINTS["charge-schedule-via-settings"],
+        "charging-settings": None,  # Reason: forbidden; use soc-levels instead
         "cockpit": _DEFAULT_ENDPOINTS["cockpit"],
         "hvac-settings": _DEFAULT_ENDPOINTS["hvac-settings"],
         "hvac-status": _DEFAULT_ENDPOINTS["hvac-status"],
         "location": _DEFAULT_ENDPOINTS["location"],
         "lock-status": None,
+        "pressure": None,  # Reason: notFound; no TPMS data for this vin
         "res-state": None,
+        "soc-levels": _DEFAULT_ENDPOINTS["soc-levels"],
     },
     "XCB1VE": {  # MEGANE E-TECH
         "actions/charge-set-schedule": _KCM_ENDPOINTS["actions/charge-set-schedule"],


### PR DESCRIPTION
Follow-up to #1638 and #2237. Per #1747's guide, tested every endpoint that logs the "not documented" warning for this model with the CLI against a real XCB1SE (Scenic E-Tech).

- `actions/charge-start`: was falling back to the default `actions/charging-start` endpoint, which this account/model rejects (`err.func.wired.forbidden`). Fixed to use `actions/charge-start-via-settings` (same mechanism as other Scenic E-Tech / R5 E-Tech entries) — confirmed working on the real vehicle (charge started ~30s after the call).
- `actions/charge-stop`: both known approaches rejected (default → `err.func.wired.invalid-body-format`, `kcm-pause-resume` → `err.func.wired.forbidden`). Documented as `None` with the errors noted in a comment rather than left undocumented.
- `actions/horn-start`, `actions/hvac-start`, `actions/lights-start`: already work via `_DEFAULT_ENDPOINTS`, just silencing the warning.
- `charging-settings`: `err.func.wired.forbidden`, but redundant — `soc-levels` (the KCM one, already the correct default) returns the same charge-limit data fine.
- `pressure`: `err.func.wired.notFound` — no TPMS data reported for this vin, same shape as other models with `pressure: None`.
- `soc-levels`: already correct via `_DEFAULT_ENDPOINTS`, just silencing the warning.

Raw CLI transcripts for each of the above are in #2237.

Fixes #2237