### PR TITLE
Update documentation for A5E1AE (Alpine A290)

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -206,6 +206,7 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "actions/hvac-start": _DEFAULT_ENDPOINTS["actions/hvac-start"],
         "actions/hvac-stop": _KCA_ALTERNATIVE_ENDPOINTS["actions/hvac-stop"],
         "actions/lights-start": _DEFAULT_ENDPOINTS["actions/lights-start"],
+        "actions/refresh-location": _DEFAULT_ENDPOINTS["actions/refresh-location"],
         "alerts": None,  # Reason: err.func.wired.not-found
         "battery-status": _DEFAULT_ENDPOINTS["battery-status"],
         "charge-history": None,  # Reason: err.func.wired.not-found

--- a/tests/__snapshots__/test_renault_vehicle.ambr
+++ b/tests/__snapshots__/test_renault_vehicle.ambr
@@ -146,6 +146,10 @@
       endpoint='/kca/car-adapter/v1/cars/{vin}/actions/horn-lights',
       mode='default',
     ),
+    'actions/refresh-location': EndpointDefinition(
+      endpoint='/kca/car-adapter/v1/cars/{vin}/actions/refresh-location',
+      mode='default',
+    ),
     'alerts': None,
     'battery-status': EndpointDefinition(
       endpoint='/kca/car-adapter/v2/cars/{vin}/battery-status',


### PR DESCRIPTION
First of two PRs splitting out #2250, as requested.

`actions/refresh-location` is absent from the `A5E1AE` entry, so the library falls back with this on every start:

```
Endpoint actions/refresh-location for model A5E1AE is not documented, using default endpoints
```

**The default endpoint works on this vehicle.** Verified against a real Alpine A290 (`en_GB`): invoking it produced a response from the car 12 seconds later, with the `location` `lastUpdateTime` advancing to match.

`A5E1AE` was derived from `R5E1VE`, which already declares this endpoint, so the line appears simply to have been missed in the copy. `XHN1ML` gained the same entry in #2252.

Snapshot regenerated with `--snapshot-update`; full suite passes (366 passed, 30 skipped), with the same warning count as a clean `main`.

Refs #2250