### PR TITLE
Update documentation for A5E1AE (Alpine A290)

### DIFF
--- a/src/renault_api/kamereon/models.py
+++ b/src/renault_api/kamereon/models.py
@@ -216,7 +216,7 @@ _VEHICLE_ENDPOINTS: dict[str, dict[str, EndpointDefinition | None]] = {
         "cockpit": _DEFAULT_ENDPOINTS["cockpit"],
         "hvac-history": None,  # Reason: err.func.wired.not-found
         "hvac-sessions": None,  # Reason: err.func.wired.not-found
-        "hvac-settings": _DEFAULT_ENDPOINTS["hvac-settings"],
+        "hvac-settings": None,  # Reason: errorCode 502000 (technical) on every call
         "hvac-status": _DEFAULT_ENDPOINTS["hvac-status"],
         "location": _DEFAULT_ENDPOINTS["location"],
         "lock-status": None,  # Reason: err.func.wired.notFound

--- a/tests/__snapshots__/test_renault_vehicle.ambr
+++ b/tests/__snapshots__/test_renault_vehicle.ambr
@@ -168,10 +168,7 @@
     ),
     'hvac-history': None,
     'hvac-sessions': None,
-    'hvac-settings': EndpointDefinition(
-      endpoint='/kca/car-adapter/v1/cars/{vin}/hvac-settings',
-      mode='default',
-    ),
+    'hvac-settings': None,
     'hvac-status': EndpointDefinition(
       endpoint='/kca/car-adapter/v1/cars/{vin}/hvac-status',
       mode='default',


### PR DESCRIPTION
Second of two PRs splitting out #2250, as requested. Independent of #2254 — separate branches, both cut from current `main`.

The `A5E1AE` entry declares `hvac-settings`, but the endpoint is not available on this model. Every call returns:

```
errorCode 502000, errorMessage "something went wrong", errorLevel error, errorType technical
```

Measured on a real Alpine A290 (`en_GB`) over a continuous **7 h 35 m** window at a 5-minute poll interval:

| | |
|---|---|
| Calls | ~94 |
| Successes | **0** |
| Failure | identical every time |

The responses carried four distinct `error_reference` prefixes, so the failure is consistent across several backend instances rather than one unhealthy node. (Values omitted deliberately — they look like session/trace identifiers.)

**This matters beyond the log noise:** `supports_endpoint("hvac-settings")` reads this table, so it returns `True` for `A5E1AE` while every call fails — a consumer that gates on advertised support still calls a permanently failing endpoint. That is not hypothetical; it cost a downstream add-on a release that gated on `supports_endpoint()` and changed nothing.

Set to `None` with a reason, matching the style already used for `pressure` and `lock-status` in the same entry.

I cannot say whether this is a sustained Renault-side outage for this model or a genuine absence — only that it has been total over the measured window. Happy to re-test on request; the vehicle is available.

Snapshot regenerated with `--snapshot-update`; full suite passes (366 passed, 30 skipped), with the same warning count as a clean `main`.

Refs #2250