### PR TITLE
Add email one-time-code two-factor authentication support

### DIFF
--- a/src/renault_api/gigya/__init__.py
+++ b/src/renault_api/gigya/__init__.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import aiohttp
 from marshmallow.schema import Schema
+from yarl import URL
 
 from . import models
 from . import schemas
@@ -26,9 +27,12 @@ async def request(
     url: str,
     data: dict[str, Any],
     schema: Schema,
+    params: dict[str, Any] | None = None,
 ) -> models.GigyaResponse:
     """Send request to Gigya."""
-    async with websession.request(method, url, data=data) as http_response:
+    async with websession.request(
+        method, url, data=data, params=params
+    ) as http_response:
         response_text = await http_response.text()
         # Don't log on Gigya, to avoid unnecessary exposure.
         try:
@@ -111,4 +115,166 @@ async def get_jwt(
             },
             schema=schemas.GigyaGetJWTResponseSchema,
         ),
+    )
+
+
+async def _get_tfa_bootstrap_cookies(
+    websession: aiohttp.ClientSession,
+    root_url: str,
+    api_key: str,
+) -> dict[str, str]:
+    """Send GET to /accounts.webSdkBootstrap and return the resulting cookies.
+
+    The two-factor-authentication endpoints below require the `ucid`/`gmid`
+    cookies set by this call to also be sent back as query parameters.
+    """
+    async with websession.request(
+        "GET",
+        f"{root_url}/accounts.webSdkBootstrap",
+        params={"APIKey": api_key},
+    ) as http_response:
+        http_response.raise_for_status()
+
+    jar_cookies = websession.cookie_jar.filter_cookies(URL(root_url))
+    return {
+        name: jar_cookies[name].value
+        for name in ("ucid", "gmid")
+        if name in jar_cookies
+    }
+
+
+async def init_tfa(
+    websession: aiohttp.ClientSession,
+    root_url: str,
+    api_key: str,
+    reg_token: str,
+) -> models.GigyaTfaInitResponse:
+    """Send GET to /accounts.tfa.initTFA to start an email one-time-code challenge.
+
+    `reg_token` comes from `PendingTwoFactorAuthenticationException.reg_token`,
+    raised by `login` when the account requires two-factor authentication.
+    """
+    cookies = await _get_tfa_bootstrap_cookies(websession, root_url, api_key)
+    return cast(
+        models.GigyaTfaInitResponse,
+        await request(
+            websession,
+            "GET",
+            f"{root_url}/accounts.tfa.initTFA",
+            data={},
+            params={
+                "APIKey": api_key,
+                "regToken": reg_token,
+                "provider": "gigyaEmail",
+                "mode": "verify",
+                **cookies,
+            },
+            schema=schemas.GigyaTfaInitResponseSchema,
+        ),
+    )
+
+
+async def get_tfa_emails(
+    websession: aiohttp.ClientSession,
+    root_url: str,
+    api_key: str,
+    gigya_assertion: str,
+) -> models.GigyaTfaEmailListResponse:
+    """Send GET to /accounts.tfa.email.getEmails to list the emails eligible for TFA."""
+    return cast(
+        models.GigyaTfaEmailListResponse,
+        await request(
+            websession,
+            "GET",
+            f"{root_url}/accounts.tfa.email.getEmails",
+            data={},
+            params={"APIKey": api_key, "gigyaAssertion": gigya_assertion},
+            schema=schemas.GigyaTfaEmailListResponseSchema,
+        ),
+    )
+
+
+async def send_tfa_email_code(
+    websession: aiohttp.ClientSession,
+    root_url: str,
+    api_key: str,
+    gigya_assertion: str,
+    email_id: str,
+) -> models.GigyaTfaSendEmailCodeResponse:
+    """Send GET to /accounts.tfa.email.sendVerificationCode to email the OTP code."""
+    return cast(
+        models.GigyaTfaSendEmailCodeResponse,
+        await request(
+            websession,
+            "GET",
+            f"{root_url}/accounts.tfa.email.sendVerificationCode",
+            data={},
+            params={
+                "APIKey": api_key,
+                "gigyaAssertion": gigya_assertion,
+                "emailID": email_id,
+            },
+            schema=schemas.GigyaTfaSendEmailCodeResponseSchema,
+        ),
+    )
+
+
+async def complete_tfa_email_verification(
+    websession: aiohttp.ClientSession,
+    root_url: str,
+    api_key: str,
+    gigya_assertion: str,
+    phv_token: str,
+    code: str,
+) -> models.GigyaTfaEmailCompleteVerificationResponse:
+    """Send GET to /accounts.tfa.email.completeVerification with the emailed code."""
+    return cast(
+        models.GigyaTfaEmailCompleteVerificationResponse,
+        await request(
+            websession,
+            "GET",
+            f"{root_url}/accounts.tfa.email.completeVerification",
+            data={},
+            params={
+                "APIKey": api_key,
+                "gigyaAssertion": gigya_assertion,
+                "phvToken": phv_token,
+                "code": code,
+            },
+            schema=schemas.GigyaTfaEmailCompleteVerificationResponseSchema,
+        ),
+    )
+
+
+async def finalize_tfa(
+    websession: aiohttp.ClientSession,
+    root_url: str,
+    api_key: str,
+    gigya_assertion: str,
+    provider_assertion: str,
+    reg_token: str,
+    *,
+    remember_device: bool = True,
+) -> None:
+    """Send GET to /accounts.tfa.finalizeTFA to complete the TFA challenge.
+
+    Afterwards, call `login` again with the same credentials to obtain the
+    now-valid Gigya login token; `finalizeTFA` itself does not return one.
+    `remember_device` maps to Gigya's `tempDevice` flag (inverted): when
+    `True`, the device is remembered for future logins (no repeat TFA for
+    about 30 days), matching Gigya's own web client default.
+    """
+    await request(
+        websession,
+        "GET",
+        f"{root_url}/accounts.tfa.finalizeTFA",
+        data={},
+        params={
+            "APIKey": api_key,
+            "gigyaAssertion": gigya_assertion,
+            "providerAssertion": provider_assertion,
+            "regToken": reg_token,
+            "tempDevice": str(not remember_device).lower(),
+        },
+        schema=schemas.GigyaResponseSchema,
     )

--- a/src/renault_api/gigya/exceptions.py
+++ b/src/renault_api/gigya/exceptions.py
@@ -22,3 +22,19 @@ class InvalidCredentialsException(GigyaResponseException):
     """Invalid loginID or password."""
 
     pass
+
+
+class PendingTwoFactorAuthenticationException(GigyaResponseException):
+    """Account requires two-factor authentication (Gigya errorCode 403101).
+
+    See https://github.com/hacf-fr/renault-api/issues/2132 for background on
+    when Gigya started enforcing this. Catch this exception after calling
+    `RenaultSession.login`, then drive the challenge with
+    `RenaultSession.request_two_factor_auth_code` and
+    `RenaultSession.complete_two_factor_auth`.
+    """
+
+    def __init__(self, error_code: int, error_details: str | None, reg_token: str):
+        """Initialise PendingTwoFactorAuthenticationException."""
+        super().__init__(error_code, error_details)
+        self.reg_token = reg_token

--- a/src/renault_api/gigya/models.py
+++ b/src/renault_api/gigya/models.py
@@ -14,16 +14,24 @@ COMMON_ERRRORS: list[dict[str, Any]] = [
 ]
 
 
+TFA_PENDING_ERROR_CODE = 403101
+
+
 @dataclass
 class GigyaResponse(BaseModel):
     """Gigya response."""
 
     errorCode: int
     errorDetails: str | None
+    regToken: str | None
 
     def raise_for_error_code(self) -> None:
         """Checks the response information."""
         if self.errorCode > 0:
+            if self.errorCode == TFA_PENDING_ERROR_CODE and self.regToken:
+                raise exceptions.PendingTwoFactorAuthenticationException(
+                    self.errorCode, self.errorDetails, self.regToken
+                )
             for common_error in COMMON_ERRRORS:
                 if self.errorCode == common_error["errorCode"]:
                     error_type = common_error["error_type"]
@@ -92,3 +100,70 @@ class GigyaGetJWTResponse(GigyaResponse):
         if not self.id_token:
             raise exceptions.GigyaException("`id_token` is None in GetJWT response.")
         return self.id_token
+
+
+@dataclass
+class GigyaTfaInitResponse(GigyaResponse):
+    """Gigya response to GET on /accounts.tfa.initTFA."""
+
+    gigyaAssertion: str | None
+
+    def get_gigya_assertion(self) -> str:
+        """Return the assertion identifying this TFA challenge."""
+        if not self.gigyaAssertion:
+            raise exceptions.GigyaException(
+                "`gigyaAssertion` is None in initTFA response."
+            )
+        return self.gigyaAssertion
+
+
+@dataclass
+class GigyaTfaEmail(BaseModel):
+    """A single email address registered for TFA verification."""
+
+    id: str | None
+
+
+@dataclass
+class GigyaTfaEmailListResponse(GigyaResponse):
+    """Gigya response to GET on /accounts.tfa.email.getEmails."""
+
+    emails: list[GigyaTfaEmail] | None
+
+    def get_email_id(self) -> str:
+        """Return the id of the (first) registered email address."""
+        if not self.emails or not self.emails[0].id:
+            raise exceptions.GigyaException(
+                "`emails` is empty in TFA email list response."
+            )
+        return self.emails[0].id
+
+
+@dataclass
+class GigyaTfaSendEmailCodeResponse(GigyaResponse):
+    """Gigya response to GET on /accounts.tfa.email.sendVerificationCode."""
+
+    phvToken: str | None
+
+    def get_phv_token(self) -> str:
+        """Return the token identifying the sent verification email."""
+        if not self.phvToken:
+            raise exceptions.GigyaException(
+                "`phvToken` is None in sendVerificationCode response."
+            )
+        return self.phvToken
+
+
+@dataclass
+class GigyaTfaEmailCompleteVerificationResponse(GigyaResponse):
+    """Gigya response to GET on /accounts.tfa.email.completeVerification."""
+
+    providerAssertion: str | None
+
+    def get_provider_assertion(self) -> str:
+        """Return the assertion proving the emailed code was verified."""
+        if not self.providerAssertion:
+            raise exceptions.GigyaException(
+                "`providerAssertion` is None in completeVerification response."
+            )
+        return self.providerAssertion

--- a/src/renault_api/gigya/schemas.py
+++ b/src/renault_api/gigya/schemas.py
@@ -23,3 +23,23 @@ GigyaGetAccountInfoResponseSchema = marshmallow_dataclass.class_schema(
 GigyaGetJWTResponseSchema = marshmallow_dataclass.class_schema(
     models.GigyaGetJWTResponse, base_schema=BaseSchema
 )()
+
+
+GigyaTfaInitResponseSchema = marshmallow_dataclass.class_schema(
+    models.GigyaTfaInitResponse, base_schema=BaseSchema
+)()
+
+
+GigyaTfaEmailListResponseSchema = marshmallow_dataclass.class_schema(
+    models.GigyaTfaEmailListResponse, base_schema=BaseSchema
+)()
+
+
+GigyaTfaSendEmailCodeResponseSchema = marshmallow_dataclass.class_schema(
+    models.GigyaTfaSendEmailCodeResponse, base_schema=BaseSchema
+)()
+
+
+GigyaTfaEmailCompleteVerificationResponseSchema = marshmallow_dataclass.class_schema(
+    models.GigyaTfaEmailCompleteVerificationResponse, base_schema=BaseSchema
+)()

--- a/src/renault_api/renault_session.py
+++ b/src/renault_api/renault_session.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 import aiohttp
@@ -27,6 +28,15 @@ from renault_api.helpers import get_api_keys
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass
+class _PendingTwoFactorAuth:
+    """State needed to complete an in-progress email TFA challenge."""
+
+    reg_token: str
+    gigya_assertion: str
+    phv_token: str
+
+
 class RenaultSession:
     """Renault session for interaction with Renault servers."""
 
@@ -42,6 +52,8 @@ class RenaultSession:
         self._gigya_lock = asyncio.Lock()
         self._websession = websession
         self._credentials: CredentialStore = credential_store or CredentialStore()
+        self._pending_login: tuple[str, str] | None = None
+        self._tfa: _PendingTwoFactorAuth | None = None
 
         if locale_details:
             for k, v in locale_details.items():
@@ -52,8 +64,18 @@ class RenaultSession:
             self._credentials[CONF_COUNTRY] = Credential(country)
 
     async def login(self, login_id: str, password: str) -> None:
-        """Attempt login on Gigya."""
+        """Attempt login on Gigya.
+
+        Raises `PendingTwoFactorAuthenticationException` if the account
+        requires two-factor authentication (see
+        https://github.com/hacf-fr/renault-api/issues/2132). Catch it, then
+        call `request_two_factor_auth_code` followed by
+        `complete_two_factor_auth` (which calls back into `login`) to finish.
+        """
         self._credentials.clear_keys(gigya.GIGYA_KEYS)
+        # Kept in memory (never persisted) so `complete_two_factor_auth` can
+        # replay the login once the pending TFA challenge is resolved.
+        self._pending_login = (login_id, password)
 
         response = await gigya.login(
             self._websession,
@@ -64,6 +86,83 @@ class RenaultSession:
         )
         credential = Credential(response.get_session_cookie())
         self._credentials[gigya.GIGYA_LOGIN_TOKEN] = credential
+        self._pending_login = None
+
+    async def request_two_factor_auth_code(self, reg_token: str) -> None:
+        """Start an email one-time-code two-factor authentication challenge.
+
+        `reg_token` comes from `PendingTwoFactorAuthenticationException.reg_token`,
+        raised by `login`. This emails a one-time code to the account's
+        registered address; pass it to `complete_two_factor_auth` once known.
+        Currently only the email one-time-code method is supported.
+        """
+        root_url = await self._get_gigya_root_url()
+        api_key = await self._get_gigya_api_key()
+
+        init_response = await gigya.init_tfa(
+            self._websession, root_url, api_key, reg_token
+        )
+        gigya_assertion = init_response.get_gigya_assertion()
+
+        emails_response = await gigya.get_tfa_emails(
+            self._websession, root_url, api_key, gigya_assertion
+        )
+        email_id = emails_response.get_email_id()
+
+        send_response = await gigya.send_tfa_email_code(
+            self._websession, root_url, api_key, gigya_assertion, email_id
+        )
+        self._tfa = _PendingTwoFactorAuth(
+            reg_token=reg_token,
+            gigya_assertion=gigya_assertion,
+            phv_token=send_response.get_phv_token(),
+        )
+
+    async def complete_two_factor_auth(
+        self, code: str, *, remember_device: bool = True
+    ) -> None:
+        """Submit the emailed one-time code and finish logging in.
+
+        Must be called after `request_two_factor_auth_code`, on the same
+        `RenaultSession` that raised `PendingTwoFactorAuthenticationException`.
+        When `remember_device` is True (the default), Gigya should not
+        require another TFA challenge on this session for about 30 days.
+        """
+        if not self._tfa:
+            raise RenaultException(
+                "No two-factor authentication challenge is pending; "
+                "call `request_two_factor_auth_code` first."
+            )
+        if not self._pending_login:
+            raise RenaultException(
+                "`login` must be called before completing two-factor authentication."
+            )
+        tfa = self._tfa
+        root_url = await self._get_gigya_root_url()
+        api_key = await self._get_gigya_api_key()
+
+        complete_response = await gigya.complete_tfa_email_verification(
+            self._websession,
+            root_url,
+            api_key,
+            tfa.gigya_assertion,
+            tfa.phv_token,
+            code,
+        )
+        await gigya.finalize_tfa(
+            self._websession,
+            root_url,
+            api_key,
+            tfa.gigya_assertion,
+            complete_response.get_provider_assertion(),
+            tfa.reg_token,
+            remember_device=remember_device,
+        )
+        # The challenge is now resolved (the code is single-use) - clear it
+        # even if the re-login below fails, so a retry doesn't replay it.
+        self._tfa = None
+        login_id, password = self._pending_login
+        await self.login(login_id, password)
 
     @property
     def login_token(self) -> str | None:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import re
 from collections.abc import Mapping
 from glob import glob
 from os import path
@@ -12,6 +13,7 @@ from typing import Any
 import jwt
 from aiointercept import aiointercept
 from marshmallow.schema import Schema
+from multidict import CIMultiDict
 
 from tests.const import REDACTED
 from tests.const import TEST_ACCOUNT_ID
@@ -138,11 +140,127 @@ def inject_gigya_jwt(mocked_responses: aiointercept) -> str:
     )
 
 
+def inject_gigya_get(
+    mocked_responses: aiointercept,
+    urlpath: str,
+    filename: str,
+) -> str:
+    """Inject Gigya data for a GET-based endpoint (eg. two-factor auth).
+
+    Matches on path only (ignoring query string), since these endpoints are
+    called with parameters (ucid/gmid/assertions/tokens) that chain from one
+    response to the next and aren't worth pinning down here.
+    """
+    url = f"{TEST_GIGYA_URL}/{urlpath}"
+    body = get_file_content(f"{GIGYA_FIXTURE_PATH}/{filename}")
+    mocked_responses.get(
+        re.compile(f"^{re.escape(url)}"),
+        status=200,
+        body=body,
+        content_type="text/javascript",
+    )
+    return url
+
+
 def inject_gigya_all(mocked_responses: aiointercept) -> None:
     """Inject Gigya login/getAccountInfo/getJWT data."""
     inject_gigya_login(mocked_responses)
     inject_gigya_account_info(mocked_responses)
     inject_gigya_jwt(mocked_responses)
+
+
+def inject_gigya_login_403101(mocked_responses: aiointercept) -> str:
+    """Inject Gigya login response requiring two-factor authentication."""
+    return inject_gigya(
+        mocked_responses,
+        "accounts.login",
+        "error/login.403101.json",
+    )
+
+
+def inject_gigya_tfa_bootstrap(mocked_responses: aiointercept) -> str:
+    """Inject Gigya webSdkBootstrap response, setting the ucid/gmid cookies."""
+    url = f"{TEST_GIGYA_URL}/accounts.webSdkBootstrap"
+    headers = CIMultiDict(
+        [
+            ("Set-Cookie", "ucid=sample-ucid; Path=/"),
+            ("Set-Cookie", "gmid=sample-gmid; Path=/"),
+        ]
+    )
+    mocked_responses.get(
+        re.compile(f"^{re.escape(url)}"), status=200, body="", headers=headers
+    )
+    return url
+
+
+def inject_gigya_tfa_bootstrap_no_cookies(mocked_responses: aiointercept) -> str:
+    """Inject Gigya webSdkBootstrap response that sets no cookies."""
+    url = f"{TEST_GIGYA_URL}/accounts.webSdkBootstrap"
+    mocked_responses.get(re.compile(f"^{re.escape(url)}"), status=200, body="")
+    return url
+
+
+def inject_gigya_tfa_init(mocked_responses: aiointercept) -> str:
+    """Inject Gigya initTFA data."""
+    return inject_gigya_get(
+        mocked_responses,
+        "accounts.tfa.initTFA",
+        "tfa_init.json",
+    )
+
+
+def inject_gigya_tfa_emails(mocked_responses: aiointercept) -> str:
+    """Inject Gigya TFA email list data."""
+    return inject_gigya_get(
+        mocked_responses,
+        "accounts.tfa.email.getEmails",
+        "tfa_emails.json",
+    )
+
+
+def inject_gigya_tfa_send_email_code(mocked_responses: aiointercept) -> str:
+    """Inject Gigya TFA sendVerificationCode data."""
+    return inject_gigya_get(
+        mocked_responses,
+        "accounts.tfa.email.sendVerificationCode",
+        "tfa_send_email_code.json",
+    )
+
+
+def inject_gigya_tfa_complete_email_verification(mocked_responses: aiointercept) -> str:
+    """Inject Gigya TFA completeVerification data."""
+    return inject_gigya_get(
+        mocked_responses,
+        "accounts.tfa.email.completeVerification",
+        "tfa_complete_email_verification.json",
+    )
+
+
+def inject_gigya_tfa_finalize(mocked_responses: aiointercept) -> str:
+    """Inject Gigya finalizeTFA data."""
+    return inject_gigya_get(
+        mocked_responses,
+        "accounts.tfa.finalizeTFA",
+        "tfa_finalize.json",
+    )
+
+
+def inject_gigya_tfa_all(mocked_responses: aiointercept) -> None:
+    """Inject a full email-OTP two-factor-authentication challenge.
+
+    The initial `accounts.login` returns a 403101 (pending TFA); once the
+    challenge is completed, `RenaultSession.complete_two_factor_auth` calls
+    `login` again, so a second (successful) `accounts.login` response is
+    queued up behind the first.
+    """
+    inject_gigya_login_403101(mocked_responses)
+    inject_gigya_tfa_bootstrap(mocked_responses)
+    inject_gigya_tfa_init(mocked_responses)
+    inject_gigya_tfa_emails(mocked_responses)
+    inject_gigya_tfa_send_email_code(mocked_responses)
+    inject_gigya_tfa_complete_email_verification(mocked_responses)
+    inject_gigya_tfa_finalize(mocked_responses)
+    inject_gigya_login(mocked_responses)
 
 
 def inject_data(

--- a/tests/fixtures/gigya/error/login.403101.json
+++ b/tests/fixtures/gigya/error/login.403101.json
@@ -1,0 +1,1 @@
+{"callId":"callId","errorCode":403101,"errorDetails":"Pending Two-Factor Authentication","apiVersion":2,"statusCode":403,"statusReason":"Forbidden","time":"2020-11-17T08:22:36.561Z","regToken":"sample-reg-token"}

--- a/tests/fixtures/gigya/tfa_complete_email_verification.json
+++ b/tests/fixtures/gigya/tfa_complete_email_verification.json
@@ -1,0 +1,1 @@
+{"callId":"callId","errorCode":0,"apiVersion":2,"statusCode":200,"statusReason":"OK","time":"2020-11-10T08:31:02.637Z","providerAssertion":"sample-provider-assertion"}

--- a/tests/fixtures/gigya/tfa_emails.json
+++ b/tests/fixtures/gigya/tfa_emails.json
@@ -1,0 +1,1 @@
+{"callId":"callId","errorCode":0,"apiVersion":2,"statusCode":200,"statusReason":"OK","time":"2020-11-10T08:31:02.637Z","emails":[{"id":"sample-email-id","obfuscated":"s***@email.com"}]}

--- a/tests/fixtures/gigya/tfa_finalize.json
+++ b/tests/fixtures/gigya/tfa_finalize.json
@@ -1,0 +1,1 @@
+{"callId":"callId","errorCode":0,"apiVersion":2,"statusCode":200,"statusReason":"OK","time":"2020-11-10T08:31:02.637Z"}

--- a/tests/fixtures/gigya/tfa_init.json
+++ b/tests/fixtures/gigya/tfa_init.json
@@ -1,0 +1,1 @@
+{"callId":"callId","errorCode":0,"apiVersion":2,"statusCode":200,"statusReason":"OK","time":"2020-11-10T08:31:02.637Z","gigyaAssertion":"sample-gigya-assertion"}

--- a/tests/fixtures/gigya/tfa_send_email_code.json
+++ b/tests/fixtures/gigya/tfa_send_email_code.json
@@ -1,0 +1,1 @@
+{"callId":"callId","errorCode":0,"apiVersion":2,"statusCode":200,"statusReason":"OK","time":"2020-11-10T08:31:02.637Z","phvToken":"sample-phv-token"}

--- a/tests/gigya/test_gigya.py
+++ b/tests/gigya/test_gigya.py
@@ -79,3 +79,97 @@ async def test_get_jwt_token(
         TEST_LOGIN_TOKEN,
     )
     assert response.get_jwt()
+
+
+@pytest.mark.asyncio
+async def test_init_tfa(
+    websession: aiohttp.ClientSession, mocked_responses: aiointercept
+) -> None:
+    """Test initTFA response."""
+    fixtures.inject_gigya_tfa_bootstrap(mocked_responses)
+    fixtures.inject_gigya_tfa_init(mocked_responses)
+
+    response = await gigya.init_tfa(
+        websession, TEST_GIGYA_URL, TEST_GIGYA_APIKEY, "sample-reg-token"
+    )
+    assert response.get_gigya_assertion() == "sample-gigya-assertion"
+
+
+@pytest.mark.asyncio
+async def test_init_tfa_without_bootstrap_cookies(
+    websession: aiohttp.ClientSession, mocked_responses: aiointercept
+) -> None:
+    """Test initTFA still works if webSdkBootstrap sets no cookies."""
+    fixtures.inject_gigya_tfa_bootstrap_no_cookies(mocked_responses)
+    fixtures.inject_gigya_tfa_init(mocked_responses)
+
+    response = await gigya.init_tfa(
+        websession, TEST_GIGYA_URL, TEST_GIGYA_APIKEY, "sample-reg-token"
+    )
+    assert response.get_gigya_assertion() == "sample-gigya-assertion"
+
+
+@pytest.mark.asyncio
+async def test_get_tfa_emails(
+    websession: aiohttp.ClientSession, mocked_responses: aiointercept
+) -> None:
+    """Test TFA email list response."""
+    fixtures.inject_gigya_tfa_emails(mocked_responses)
+
+    response = await gigya.get_tfa_emails(
+        websession, TEST_GIGYA_URL, TEST_GIGYA_APIKEY, "sample-gigya-assertion"
+    )
+    assert response.get_email_id() == "sample-email-id"
+
+
+@pytest.mark.asyncio
+async def test_send_tfa_email_code(
+    websession: aiohttp.ClientSession, mocked_responses: aiointercept
+) -> None:
+    """Test sendVerificationCode response."""
+    fixtures.inject_gigya_tfa_send_email_code(mocked_responses)
+
+    response = await gigya.send_tfa_email_code(
+        websession,
+        TEST_GIGYA_URL,
+        TEST_GIGYA_APIKEY,
+        "sample-gigya-assertion",
+        "sample-email-id",
+    )
+    assert response.get_phv_token() == "sample-phv-token"
+
+
+@pytest.mark.asyncio
+async def test_complete_tfa_email_verification(
+    websession: aiohttp.ClientSession, mocked_responses: aiointercept
+) -> None:
+    """Test completeVerification response."""
+    fixtures.inject_gigya_tfa_complete_email_verification(mocked_responses)
+
+    response = await gigya.complete_tfa_email_verification(
+        websession,
+        TEST_GIGYA_URL,
+        TEST_GIGYA_APIKEY,
+        "sample-gigya-assertion",
+        "sample-phv-token",
+        "123456",
+    )
+    assert response.get_provider_assertion() == "sample-provider-assertion"
+
+
+@pytest.mark.asyncio
+async def test_finalize_tfa(
+    websession: aiohttp.ClientSession, mocked_responses: aiointercept
+) -> None:
+    """Test finalizeTFA response."""
+    fixtures.inject_gigya_tfa_finalize(mocked_responses)
+
+    await gigya.finalize_tfa(
+        websession,
+        TEST_GIGYA_URL,
+        TEST_GIGYA_APIKEY,
+        "sample-gigya-assertion",
+        "sample-provider-assertion",
+        "sample-reg-token",
+        remember_device=False,
+    )

--- a/tests/gigya/test_gigya_error.py
+++ b/tests/gigya/test_gigya_error.py
@@ -55,3 +55,32 @@ def test_login_403042_response() -> None:
         response.raise_for_error_code()
     assert excinfo.value.error_code == 403042
     assert excinfo.value.error_details == "invalid loginID or password"
+
+
+def test_login_403101_response() -> None:
+    """Test login.403101 (pending two-factor authentication) response."""
+    response: models.GigyaLoginResponse = fixtures.get_file_content_as_schema(
+        f"{fixtures.GIGYA_FIXTURE_PATH}/error/login.403101.json",
+        schemas.GigyaLoginResponseSchema,
+    )
+    with pytest.raises(exceptions.PendingTwoFactorAuthenticationException) as excinfo:
+        response.raise_for_error_code()
+    assert excinfo.value.error_code == 403101
+    assert excinfo.value.error_details == "Pending Two-Factor Authentication"
+    assert excinfo.value.reg_token == "sample-reg-token"
+
+
+def test_403101_without_reg_token() -> None:
+    """A 403101 error without a regToken falls back to a generic error.
+
+    This shouldn't happen in practice, but avoids raising
+    `PendingTwoFactorAuthenticationException` with no usable `reg_token`.
+    """
+    response = models.GigyaResponse(
+        raw_data={}, errorCode=403101, errorDetails="test", regToken=None
+    )
+    with pytest.raises(exceptions.GigyaResponseException) as excinfo:
+        response.raise_for_error_code()
+    assert not isinstance(
+        excinfo.value, exceptions.PendingTwoFactorAuthenticationException
+    )

--- a/tests/gigya/test_gigya_models.py
+++ b/tests/gigya/test_gigya_models.py
@@ -4,6 +4,7 @@ import pytest
 
 from tests import fixtures
 
+from renault_api.gigya import exceptions
 from renault_api.gigya import models
 from renault_api.gigya import schemas
 
@@ -45,3 +46,85 @@ def test_get_jwt_response() -> None:
     )
     response.raise_for_error_code()
     assert response.get_jwt() == "sample-jwt-token"
+
+
+def test_tfa_init_response() -> None:
+    """Test initTFA response."""
+    response: models.GigyaTfaInitResponse = fixtures.get_file_content_as_schema(
+        f"{fixtures.GIGYA_FIXTURE_PATH}/tfa_init.json",
+        schemas.GigyaTfaInitResponseSchema,
+    )
+    response.raise_for_error_code()
+    assert response.get_gigya_assertion() == "sample-gigya-assertion"
+
+
+def test_tfa_init_response_missing_assertion() -> None:
+    """Test initTFA response with no gigyaAssertion."""
+    response = models.GigyaTfaInitResponse(
+        raw_data={}, errorCode=0, errorDetails=None, regToken=None, gigyaAssertion=None
+    )
+    with pytest.raises(exceptions.GigyaException):
+        response.get_gigya_assertion()
+
+
+def test_tfa_emails_response() -> None:
+    """Test TFA email list response."""
+    response: models.GigyaTfaEmailListResponse = fixtures.get_file_content_as_schema(
+        f"{fixtures.GIGYA_FIXTURE_PATH}/tfa_emails.json",
+        schemas.GigyaTfaEmailListResponseSchema,
+    )
+    response.raise_for_error_code()
+    assert response.get_email_id() == "sample-email-id"
+
+
+def test_tfa_emails_response_empty() -> None:
+    """Test TFA email list response with no registered emails."""
+    response = models.GigyaTfaEmailListResponse(
+        raw_data={}, errorCode=0, errorDetails=None, regToken=None, emails=[]
+    )
+    with pytest.raises(exceptions.GigyaException):
+        response.get_email_id()
+
+
+def test_tfa_send_email_code_response() -> None:
+    """Test sendVerificationCode response."""
+    response: models.GigyaTfaSendEmailCodeResponse = (
+        fixtures.get_file_content_as_schema(
+            f"{fixtures.GIGYA_FIXTURE_PATH}/tfa_send_email_code.json",
+            schemas.GigyaTfaSendEmailCodeResponseSchema,
+        )
+    )
+    response.raise_for_error_code()
+    assert response.get_phv_token() == "sample-phv-token"
+
+
+def test_tfa_send_email_code_response_missing_token() -> None:
+    """Test sendVerificationCode response with no phvToken."""
+    response = models.GigyaTfaSendEmailCodeResponse(
+        raw_data={}, errorCode=0, errorDetails=None, regToken=None, phvToken=None
+    )
+    with pytest.raises(exceptions.GigyaException):
+        response.get_phv_token()
+
+
+def test_tfa_complete_email_verification_response() -> None:
+    """Test completeVerification response."""
+    response = fixtures.get_file_content_as_schema(
+        f"{fixtures.GIGYA_FIXTURE_PATH}/tfa_complete_email_verification.json",
+        schemas.GigyaTfaEmailCompleteVerificationResponseSchema,
+    )
+    response.raise_for_error_code()
+    assert response.get_provider_assertion() == "sample-provider-assertion"
+
+
+def test_tfa_complete_email_verification_response_missing_assertion() -> None:
+    """Test completeVerification response with no providerAssertion."""
+    response = models.GigyaTfaEmailCompleteVerificationResponse(
+        raw_data={},
+        errorCode=0,
+        errorDetails=None,
+        regToken=None,
+        providerAssertion=None,
+    )
+    with pytest.raises(exceptions.GigyaException):
+        response.get_provider_assertion()

--- a/tests/test_renault_session.py
+++ b/tests/test_renault_session.py
@@ -21,6 +21,7 @@ from renault_api.exceptions import NotAuthenticatedException
 from renault_api.exceptions import RenaultException
 from renault_api.gigya import GIGYA_JWT
 from renault_api.gigya import GIGYA_LOGIN_TOKEN
+from renault_api.gigya.exceptions import PendingTwoFactorAuthenticationException
 from renault_api.renault_session import RenaultSession
 
 
@@ -251,3 +252,58 @@ async def test_expired_login_token(
         assert await session._get_jwt()
 
     assert len(mocked_responses.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_two_factor_auth(
+    session: RenaultSession, mocked_responses: aiointercept
+) -> None:
+    """Test the full email one-time-code two-factor-authentication flow."""
+    fixtures.inject_gigya_tfa_all(mocked_responses)
+    fixtures.inject_gigya_account_info(mocked_responses)
+    fixtures.inject_gigya_jwt(mocked_responses)
+
+    with pytest.raises(PendingTwoFactorAuthenticationException) as excinfo:
+        await session.login(TEST_USERNAME, TEST_PASSWORD)
+    assert excinfo.value.reg_token == "sample-reg-token"
+
+    # Gigya login token isn't available yet: the challenge isn't resolved.
+    with pytest.raises(NotAuthenticatedException):
+        await session._get_login_token()
+
+    await session.request_two_factor_auth_code(excinfo.value.reg_token)
+    await session.complete_two_factor_auth("123456")
+
+    assert await session._get_login_token() == TEST_LOGIN_TOKEN
+    assert await session._get_person_id() == TEST_PERSON_ID
+    assert await session._get_jwt()
+
+
+@pytest.mark.asyncio
+async def test_complete_two_factor_auth_without_pending_challenge(
+    session: RenaultSession,
+) -> None:
+    """Test error completing TFA without a pending challenge."""
+    with pytest.raises(
+        RenaultException,
+        match="No two-factor authentication challenge is pending",
+    ):
+        await session.complete_two_factor_auth("123456")
+
+
+@pytest.mark.asyncio
+async def test_complete_two_factor_auth_without_login(
+    session: RenaultSession, mocked_responses: aiointercept
+) -> None:
+    """Test error completing TFA if `login` was never called first."""
+    fixtures.inject_gigya_tfa_bootstrap(mocked_responses)
+    fixtures.inject_gigya_tfa_init(mocked_responses)
+    fixtures.inject_gigya_tfa_emails(mocked_responses)
+    fixtures.inject_gigya_tfa_send_email_code(mocked_responses)
+
+    await session.request_two_factor_auth_code("sample-reg-token")
+    with pytest.raises(
+        RenaultException,
+        match="`login` must be called before completing two-factor authentication.",
+    ):
+        await session.complete_two_factor_auth("123456")


### PR DESCRIPTION
## Summary

Renault/Gigya now requires two-factor authentication on `accounts.login` for some/all accounts (#2132). This adds support for the email one-time-code TFA flow, reverse-engineered from the flow used by the official app/website.

Closes #2132.

## Flow

`accounts.login` now returns error code `403101` (pending TFA) with a `regToken` instead of a session cookie when TFA is required. Resolving it requires:

1. `accounts.webSdkBootstrap` — sets `ucid`/`gmid` cookies needed by the following calls.
2. `accounts.tfa.initTFA` (with `regToken`) → `gigyaAssertion`.
3. `accounts.tfa.email.getEmails` (with `gigyaAssertion`) → the registered email's `id`.
4. `accounts.tfa.email.sendVerificationCode` → `phvToken`, and an email is sent to the user.
5. `accounts.tfa.email.completeVerification` (with the user-supplied code + `phvToken` + `gigyaAssertion`) → `providerAssertion`.
6. `accounts.tfa.finalizeTFA` (with `providerAssertion` + `gigyaAssertion` + `regToken`).
7. Re-POST `accounts.login` to get the actual session cookie.

## Changes

- `gigya`: new `init_tfa`, `get_tfa_emails`, `send_tfa_email_code`, `complete_tfa_email_verification` and `finalize_tfa` functions covering the `accounts.tfa.*` endpoints above, plus the `accounts.webSdkBootstrap` cookie bootstrap they require.
- `gigya.models`: new response models for the above endpoints, and a `regToken` field on `GigyaResponse` so `403101` errors raise a new `PendingTwoFactorAuthenticationException` carrying the `reg_token` needed to start the challenge.
- `RenaultSession`: `login()` now raises `PendingTwoFactorAuthenticationException` when TFA is required. Two new public methods drive the challenge to completion:
  - `request_two_factor_auth_code(reg_token)` — starts the challenge and emails the one-time code.
  - `complete_two_factor_auth(code, remember_device=True)` — submits the code and transparently re-attempts `login()` once resolved.

Only the email one-time-code method is supported for now (I don't have an account with other TFA methods enabled to test against). Existing non-TFA accounts are unaffected — `login()` behaves exactly as before for them.

## Testing

- New code is at 100% coverage (checked with `coverage run -m pytest && coverage report`).
- `mypy` and `ruff check`/`ruff format --check` are clean on all changed files.
- Full test suite passes with no regressions (391 passed, 30 skipped locally).

I couldn't run `nox` directly (not installed in my sandbox), so I approximated the relevant sessions (mypy, ruff, tests, coverage) manually with pinned versions matching `pyproject.toml`. Happy to adjust anything that the real CI run flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)